### PR TITLE
docs: sync developer docs with v2.3 platform state

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,12 +22,17 @@ Specialized tasks are organized into skills located in `.claude/skills/`. Each s
 
 When working on tasks that match a skill's domain, read the skill's `SKILL.md` for specific instructions and supporting docs for context.
 
+### Documented Solutions
+
+`docs/solutions/` — past problems and their fixes (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.
+
 ## Development Commands
 
 - `npm run dev` - Start development server with Turbo (http://localhost:3000)
 - `npm run build` - Build the application for production
 - `npm run start` - Start production server
 - `npm run docs-coverage` - Check documentation coverage across protocol components
+- `npm run docs-drift` - Detect stale version pins in developer guides vs devkit/CLI source-of-truth tags (see `.claude/skills/audit-docs/`)
 
 ## External API Documentation
 

--- a/.claude/skills/audit-docs/.drift-allowlist
+++ b/.claude/skills/audit-docs/.drift-allowlist
@@ -1,0 +1,12 @@
+# .drift-allowlist — patterns to ignore in detect-drift.sh output.
+#
+# One pattern per line; matched as a literal substring against
+# "relative/path:line:match" findings. Blank lines and # comments are skipped.
+#
+# Use for intentional historical references (changelog entries, migration notes,
+# "as of vX" call-outs that should not auto-update).
+#
+# Example:
+#   content/docs/protocol/v2/whats-new.mdx:v2.0.0
+#
+# (whats-new.mdx is already excluded by EXCLUDE_REGEX, shown only as a template.)

--- a/.claude/skills/audit-docs/README.md
+++ b/.claude/skills/audit-docs/README.md
@@ -1,0 +1,69 @@
+# audit-docs
+
+Drift detector for the public developer-facing surface of `andamio-docs`.
+
+## What this is
+
+A small Bash script that surfaces stale version pins in MDX by comparing them
+against authoritative sources:
+
+- **Gateway tag** ← `devkit/VERSIONS` (`GATEWAY_TAG`)
+- **CLI tag**     ← latest git tag in `andamio-cli`
+
+Output is a Markdown checklist. The script is informational by default; pass
+`--strict` to make it exit non-zero on drift (e.g., for CI).
+
+## Scope
+
+Deliberately narrow — only the developer-facing surface this repo owns:
+
+| Included | Excluded |
+|---|---|
+| `content/docs/guides/developers/**` | `content/docs/protocol/v2/transactions/**` (owned by `/v2-docs-audit`, `/transaction-audit`) |
+| `content/docs/protocol/v2/state-machine/**` | `content/docs/protocol/v2/validators/**` |
+| `content/docs/getting-started.mdx` | `content/docs/protocol/v2/tokens/**` |
+| `content/docs/reference/**` | `content/docs/pioneers/**` |
+| | `whats-new.mdx`, `glossary.mdx` |
+
+Internal services (`db-api`, `atlas`, `andamioscan`, `sidecar`) are intentionally
+out of scope — only `GATEWAY_TAG` and CLI tags are consulted.
+
+## Usage
+
+```bash
+.claude/skills/audit-docs/detect-drift.sh           # informational
+.claude/skills/audit-docs/detect-drift.sh --strict  # CI mode
+```
+
+Override repo paths via env vars when not running from defaults:
+
+```bash
+DEVKIT_REPO=/path/to/devkit \
+CLI_REPO=/path/to/cli \
+.claude/skills/audit-docs/detect-drift.sh
+```
+
+## Allowlist
+
+Add intentional historical references to `.drift-allowlist` (one literal
+substring per line, `#` comments allowed). The script skips any finding whose
+`relative/path:line:match` string contains an allowlist entry.
+
+## When to run
+
+- After a sibling repo cuts a tag bump crossing a minor version
+- When a `devkit/docs/releases/vX.Y/RELEASE_REPORT.md` is being finalized
+- Before publishing a `/guide-pipeline` status update
+- Quarterly, as a fallback audit
+
+See `docs/solutions/workflow-issues/docs-release-sync-drift-2026-05-20.md` for
+the full rationale and the Layer 1 / Layer 2 / Layer 3 implementation order
+this script is the Layer 2 piece of.
+
+## Future work
+
+- Layer 1: a devkit-side hook that emits a `PUBLIC_DOCS_DELTA.md` checklist
+  from `RELEASE_REPORT.md` at release finalization time.
+- Layer 3: a quarterly `/audit-docs` skill that diffs devkit `plans/`,
+  `notes/`, and `tx-flows/` against current MDX (this directory is the
+  natural home).

--- a/.claude/skills/audit-docs/detect-drift.sh
+++ b/.claude/skills/audit-docs/detect-drift.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# detect-drift.sh — surface stale version pins in andamio-docs public developer surface.
+#
+# Sources of truth:
+#   - GATEWAY_TAG   ← devkit VERSIONS  (~/projects/01-projects/andamio-dev-kit-internal/VERSIONS)
+#   - CLI tag       ← latest git tag in andamio-cli (~/projects/01-projects/andamio-cli)
+#
+# Scope (deliberately narrow):
+#   Includes — content/docs/guides/developers/**, state-machine/**, getting-started.mdx
+#   Excludes — protocol/v2/transactions/**, validators/**, tokens/**
+#              (owned by /v2-docs-audit and /transaction-audit skills)
+#              plus historical pages (whats-new.mdx, glossary.mdx, pioneers/**)
+#
+# Allowlist: lines listed in .drift-allowlist (one "file:pattern" per line, # comments OK)
+# are skipped. Use for intentional historical version references.
+#
+# Exit code: 0 always by default. Pass --strict to exit 1 when drift is found.
+#
+# Usage:
+#   ./detect-drift.sh             # informational checklist
+#   ./detect-drift.sh --strict    # non-zero exit on drift (for CI)
+#   DOCS_REPO=… DEVKIT_REPO=… CLI_REPO=… ./detect-drift.sh   # override paths
+
+set -euo pipefail
+
+# --- Paths --------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCS_REPO="${DOCS_REPO:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+DEVKIT_REPO="${DEVKIT_REPO:-$HOME/projects/01-projects/andamio-dev-kit-internal}"
+CLI_REPO="${CLI_REPO:-$HOME/projects/01-projects/andamio-cli}"
+ALLOWLIST="$SCRIPT_DIR/.drift-allowlist"
+
+STRICT=0
+[[ "${1:-}" == "--strict" ]] && STRICT=1
+
+# --- Authoritative versions ---------------------------------------------------
+
+resolve_gateway_tag() {
+  local versions="$DEVKIT_REPO/VERSIONS"
+  [[ -r "$versions" ]] || { echo ""; return; }
+  grep '^GATEWAY_TAG=' "$versions" | cut -d= -f2 | tr -d '[:space:]'
+}
+
+resolve_cli_tag() {
+  [[ -d "$CLI_REPO/.git" ]] || { echo ""; return; }
+  git -C "$CLI_REPO" describe --tags --abbrev=0 2>/dev/null || echo ""
+}
+
+GATEWAY_TAG="$(resolve_gateway_tag)"
+CLI_TAG="$(resolve_cli_tag)"
+CLI_VER="${CLI_TAG#v}"          # 0.12.1
+GATEWAY_BASE="${GATEWAY_TAG#v}"  # 2.3.5
+
+# --- Scope --------------------------------------------------------------------
+
+INCLUDE_GLOBS=(
+  "$DOCS_REPO/content/docs/guides/developers"
+  "$DOCS_REPO/content/docs/protocol/v2/state-machine"
+  "$DOCS_REPO/content/docs/getting-started.mdx"
+  "$DOCS_REPO/content/docs/reference"
+)
+
+EXCLUDE_REGEX='/(transactions|validators|tokens|pioneers)/|/(whats-new|glossary)\.mdx$'
+
+# --- Allowlist ----------------------------------------------------------------
+
+allowed() {
+  # $1 = "relative/path:line:match" — return 0 if any allowlist pattern matches
+  [[ -r "$ALLOWLIST" ]] || return 1
+  local needle="$1"
+  while IFS= read -r pat; do
+    [[ -z "$pat" || "$pat" =~ ^# ]] && continue
+    [[ "$needle" == *"$pat"* ]] && return 0
+  done <"$ALLOWLIST"
+  return 1
+}
+
+# --- Greps --------------------------------------------------------------------
+
+# Returns lines as "relative/path:line:match"
+scan() {
+  local pattern="$1"
+  grep -rEn "$pattern" "${INCLUDE_GLOBS[@]}" 2>/dev/null \
+    | sed "s|^$DOCS_REPO/||" \
+    | grep -vE "$EXCLUDE_REGEX" || true
+}
+
+# --- Findings -----------------------------------------------------------------
+
+declare -a FINDINGS=()
+WARNINGS=()
+
+[[ -z "$GATEWAY_TAG" ]] && WARNINGS+=("Could not read GATEWAY_TAG from $DEVKIT_REPO/VERSIONS — gateway drift check skipped.")
+[[ -z "$CLI_TAG"     ]] && WARNINGS+=("Could not read CLI tag from $CLI_REPO — CLI drift check skipped.")
+
+# CLI VERSION= pins
+if [[ -n "$CLI_VER" ]]; then
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    # Extract the version number from "VERSION=X.Y.Z"
+    found_ver="$(echo "$line" | grep -oE 'VERSION=[0-9]+\.[0-9]+\.[0-9]+' | head -1 | cut -d= -f2)"
+    [[ "$found_ver" == "$CLI_VER" ]] && continue
+    allowed "$line" && continue
+    FINDINGS+=("CLI: $line  → expected VERSION=$CLI_VER")
+  done < <(scan 'VERSION=[0-9]+\.[0-9]+\.[0-9]+')
+fi
+
+# Gateway / API version pins (e.g., "v2.3.5", "v2.1.1-rc12")
+if [[ -n "$GATEWAY_BASE" ]]; then
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    found_ver="$(echo "$line" | grep -oE 'v2\.[0-9]+\.[0-9]+(-rc[0-9]+)?' | head -1)"
+    [[ "$found_ver" == "$GATEWAY_TAG" ]] && continue
+    allowed "$line" && continue
+    FINDINGS+=("API: $line  → expected $GATEWAY_TAG")
+  done < <(scan 'v2\.[0-9]+\.[0-9]+(-rc[0-9]+)?')
+fi
+
+# --- Output -------------------------------------------------------------------
+
+cat <<EOF
+# andamio-docs drift report
+
+Authoritative sources:
+- Gateway (devkit VERSIONS): ${GATEWAY_TAG:-(unavailable)}
+- CLI (latest git tag):      ${CLI_TAG:-(unavailable)}
+
+Scope: developer guides + state-machine + getting-started + reference.
+Excluded: transactions/validators/tokens (owned by /v2-docs-audit, /transaction-audit), pioneers/, whats-new.mdx, glossary.mdx.
+
+EOF
+
+if ((${#WARNINGS[@]})); then
+  echo "## Warnings"
+  for w in "${WARNINGS[@]}"; do echo "- $w"; done
+  echo
+fi
+
+if ((${#FINDINGS[@]} == 0)); then
+  echo "## Findings"
+  echo
+  echo "No drift detected. ✓"
+  exit 0
+fi
+
+echo "## Findings (${#FINDINGS[@]})"
+echo
+for f in "${FINDINGS[@]}"; do
+  echo "- [ ] $f"
+done
+
+if ((STRICT)); then
+  exit 1
+fi
+exit 0

--- a/.claude/skills/guide-pipeline/SKILL.md
+++ b/.claude/skills/guide-pipeline/SKILL.md
@@ -213,6 +213,8 @@ The `guide-tracker.json` in this directory is the shared source of truth. The `u
 - Issue states are always verified live via `gh issue view`
 - Only one Claude session operates at a time, so no concurrent conflicts
 
+This skill handles the onboarding-guides surface specifically. The broader pattern (docs drift relative to the platform release cycle) is captured in `docs/solutions/workflow-issues/docs-release-sync-drift-2026-05-20.md`, with the version-pin drift detector at `npm run docs-drift` (`.claude/skills/audit-docs/`). Before publishing a pipeline status update, run the drift detector so status reflects current reality.
+
 ## Tracker Schema Reference
 
 ```jsonc

--- a/.claude/skills/transaction-audit/SKILL.md
+++ b/.claude/skills/transaction-audit/SKILL.md
@@ -11,6 +11,8 @@ This skill is the **project manager** for V2 transaction documentation. It track
 **Worker Skill**: Use `/analyze-transaction` to process individual transactions.
 
 **Tracking File**: `.claude/skills/transaction-audit/v2-transaction-tracker.json`
+
+**Scope note**: This skill is the V2-transactions-specific instance of the broader release-cycle drift practice. For the cross-cutting pattern (release-cycle hook + drift detector + scheduled audit across the developer-facing surface), see `docs/solutions/workflow-issues/docs-release-sync-drift-2026-05-20.md`.
 </introduction>
 
 <workflow>

--- a/.claude/skills/v2-docs-audit/SKILL.md
+++ b/.claude/skills/v2-docs-audit/SKILL.md
@@ -15,6 +15,8 @@ This skill is the **documentation manager** for V2 transaction MDX files in `con
 **Related Skills**:
 - `/transaction-audit` - Tracks CBOR analysis and YAML creation
 - `/analyze-transaction` - Creates YAML + TypeScript from CBOR
+
+**Scope note**: This skill covers MDX coverage for V2 transactions only. Drift in the developer-facing guides surface (auth, CLI, sponsorship, billing) is owned by `npm run docs-drift` (`.claude/skills/audit-docs/`). The umbrella practice is `docs/solutions/workflow-issues/docs-release-sync-drift-2026-05-20.md`.
 </introduction>
 
 <workflow>

--- a/content/docs/glossary.mdx
+++ b/content/docs/glossary.mdx
@@ -114,7 +114,7 @@ Second major version of Andamio Protocol smart contracts, [independently audited
 RESTful API enabling protocol interaction without deep blockchain knowledge. Handles transaction building, signing, and submission.
 
 ### Transaction Sponsorship (Tx Sponsorship)
-Feature allowing organizations to pay blockchain transaction fees on behalf of users, removing Web3 adoption barriers.
+Feature allowing organizations to pay blockchain transaction fees on behalf of users, removing Web3 adoption barriers. Available to enterprise API keys — see [Sponsored Transactions](/docs/guides/developers/sponsored-transactions).
 
 ### Service Fees
 Protocol fees charged for certain operations, creating sustainable revenue for Andamio Inc.

--- a/content/docs/guides/developers/api-concepts.mdx
+++ b/content/docs/guides/developers/api-concepts.mdx
@@ -138,6 +138,23 @@ These endpoints extract structured data from on-chain transactions:
 
 These are useful for building activity feeds, audit logs, or debugging transaction contents.
 
+## Qualified Contributors
+
+For a project with prerequisite credentials, a manager can ask which aliases currently hold **every** required credential — useful for gating who may be assigned tasks:
+
+```text
+GET /v2/project/manager/contributors/get-qualified?project_id=<id>
+```
+
+The caller must be a manager of the project. The response includes a `status` field:
+
+| `status` | Meaning |
+|----------|---------|
+| `ok` | Prerequisites are configured; `aliases` is the set of fully-qualified contributors (may be empty if none qualify). |
+| `no_prerequisites_configured` | The project has no on-chain prerequisites; `aliases` is always empty. |
+
+The `no_prerequisites_configured` status lets you distinguish "no one qualifies yet" from "this project gates nothing" — they both return an empty list but mean very different things in your UI.
+
 ## Next Steps
 
 - [Transaction Handling](/docs/guides/developers/transactions) — The full transaction lifecycle

--- a/content/docs/guides/developers/authentication.mdx
+++ b/content/docs/guides/developers/authentication.mdx
@@ -113,7 +113,7 @@ const { jwt, expires_at, user } = await verifyRes.json();
 
 The response includes:
 - `jwt` — The authentication token
-- `expires_at` — When the JWT expires (typically 24 hours)
+- `expires_at` — When the JWT expires (short-lived; always read this value rather than assuming a fixed window)
 - `user` — User profile (alias, roles, etc.)
 
 ## What the JWT Enables
@@ -189,7 +189,7 @@ if (isJwtExpired(jwt)) {
 
 ### Refresh Strategy
 
-No refresh tokens. When a JWT expires, the user signs a new challenge. Check expiration before sensitive actions and prompt re-authentication gracefully.
+JWT lifetimes are intentionally short. When a user JWT expires, the user signs a new challenge to obtain a fresh token. Check expiration (via `expires_at` / the `exp` claim) before sensitive actions and prompt re-authentication gracefully rather than hardcoding an interval.
 
 ### Logout
 

--- a/content/docs/guides/developers/cli/installation.mdx
+++ b/content/docs/guides/developers/cli/installation.mdx
@@ -17,7 +17,7 @@ Prebuilt binaries for macOS, Linux, and Windows are available on the [Releases p
 
 ```bash
 # Example: macOS Apple Silicon — replace VERSION with the latest release
-VERSION=0.9.1
+VERSION=0.12.1
 curl -sLO "https://github.com/Andamio-Platform/andamio-cli/releases/download/v${VERSION}/andamio_${VERSION}_darwin_arm64.tar.gz"
 curl -sLO "https://github.com/Andamio-Platform/andamio-cli/releases/download/v${VERSION}/checksums.txt"
 shasum -a 256 --check --ignore-missing checksums.txt

--- a/content/docs/guides/developers/developer-accounts.mdx
+++ b/content/docs/guides/developers/developer-accounts.mdx
@@ -64,6 +64,14 @@ curl -X POST https://preprod.api.andamio.io/api/v2/auth/developer/account/login 
 
 The Developer JWT is used for account management operations (key creation, rotation, profile access). It is **not** the same as a User JWT from wallet authentication.
 
+### Wallet-Signature Login (CIP-30)
+
+Developers can also authenticate with a CIP-30 wallet signature instead of a password, using the same challenge/sign/verify pattern as [user wallet login](/docs/guides/developers/authentication). This issues a Developer JWT without a stored password.
+
+Developer JWT lifetimes are short-lived and paired with refresh-token rotation: exchange a refresh token for a new Developer JWT rather than re-running the full login when the JWT expires. Always read `exp` (or the returned `expires_at`) rather than assuming a fixed lifetime — do not hardcode an expiry window.
+
+See the [live API reference](https://preprod.api.andamio.io/reference) for the exact wallet-login and refresh endpoint schemas, which are versioned with the API.
+
 ### Developer JWT Claims
 
 ```json

--- a/content/docs/guides/developers/meta.json
+++ b/content/docs/guides/developers/meta.json
@@ -13,6 +13,7 @@
     "---",
     "api-concepts",
     "transactions",
+    "sponsored-transactions",
     "error-handling",
     "access-token-verification",
     "--- Platform ---",

--- a/content/docs/guides/developers/sponsored-transactions.mdx
+++ b/content/docs/guides/developers/sponsored-transactions.mdx
@@ -1,0 +1,130 @@
+---
+title: Sponsored Transactions
+description: Enterprise transaction sponsorship — let your organization pay blockchain fees on behalf of users
+---
+
+# Sponsored Transactions
+
+Enterprise transaction sponsorship lets your organization pay the blockchain costs of an Andamio action so the end user never needs ADA in their wallet. This removes the single biggest onboarding barrier for Web3 learning experiences.
+
+Sponsorship is opt-in and tied to an **enterprise API key**. When a sponsored route is called with an enterprise key that has remaining quota, the Andamio gateway covers the sponsor side of the transaction automatically. No request body changes are required to opt in — the gateway decides based on the key and the route.
+
+<Callout type="info">
+Sponsorship is an enterprise feature. Contact the Andamio team to provision sponsorship quota for your API key. Pioneer, Starter, and Growth tiers build self-funded transactions as described in [Transaction Handling](/docs/guides/developers/transactions).
+</Callout>
+
+## Sponsored Routes
+
+Eight transaction-build routes support sponsorship today, grouped by how quota is counted.
+
+### Bootstrap routes (route-scoped quota)
+
+These run before a `course_id` exists, so quota is counted per route:
+
+| Route | Returns |
+|-------|---------|
+| `POST /api/v2/tx/global/user/access-token/mint` | `{ tx_hash }` — submitted for you |
+| `POST /api/v2/tx/instance/owner/course/create` | `{ course_id, unsigned_tx }` — holder signs |
+
+### Course-bound routes (course-scoped quota)
+
+These act on an existing course, so quota is counted per `(api_key, course_id)`:
+
+| Route | Returns |
+|-------|---------|
+| `POST /api/v2/tx/course/owner/teachers/manage` | `{ unsigned_tx }` |
+| `POST /api/v2/tx/course/teacher/modules/manage` | `{ unsigned_tx }` |
+| `POST /api/v2/tx/course/teacher/assignments/assess` | `{ unsigned_tx }` |
+| `POST /api/v2/tx/course/student/assignment/commit` | `{ unsigned_tx }` |
+| `POST /api/v2/tx/course/student/assignment/update` | `{ unsigned_tx }` |
+| `POST /api/v2/tx/course/student/credential/claim` | `{ unsigned_tx }` |
+
+A typical enterprise lifecycle is: sponsor `access-token/mint`, then `course/create`, then downstream course-bound actions against the new `course_id`.
+
+## How a Sponsored Build Differs
+
+When a request qualifies for sponsorship, the gateway:
+
+1. **Rejects any caller-supplied `sponsor_data`.** The gateway owns the sponsor configuration — supplying your own is a `400`.
+2. Resolves quota — by route for bootstrap routes, by `course_id` for course-bound routes.
+3. Builds the transaction with the gateway's sponsor inputs and applies the sponsor signature.
+4. Returns one of two shapes (see below).
+
+You do **not** change your request body to request sponsorship. Send the same fields you would for a self-funded build.
+
+### Shape 1 — Direct submit (`access-token/mint` only)
+
+No holder signature is needed, so the gateway submits for you and returns the hash:
+
+```json
+{ "tx_hash": "<tx-hash>" }
+```
+
+### Shape 2 — Holder signs, then submits
+
+Every other sponsored route returns an unsigned transaction (plus `course_id` for `course/create`). The holder signs it and submits through the shared sponsored-submit endpoint:
+
+```json
+{ "unsigned_tx": "<tx-cbor-hex>" }
+```
+
+## Submitting a Holder-Signed Sponsored Transaction
+
+After the user signs the returned `unsigned_tx`, submit it to the shared endpoint. Do **not** submit it directly to a node — the sponsor signature is merged in by the gateway at submit time.
+
+```typescript
+const API = "https://preprod.api.andamio.io/api/v2";
+
+// 1. Build (sponsored automatically for an enterprise key)
+const { unsigned_tx } = await fetch(`${API}/tx/course/student/assignment/commit`, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "X-API-Key": ENTERPRISE_API_KEY,
+    "Authorization": `Bearer ${userJwt}`,
+  },
+  body: JSON.stringify({ alias: "student1", course_id: "abc123...", /* ... */ }),
+}).then(r => r.json());
+
+// 2. Holder signs in their wallet
+const signedTx = await wallet.signTx(unsigned_tx);
+
+// 3. Submit to the shared sponsored endpoint (NOT wallet.submitTx)
+const { tx_hash } = await fetch(`${API}/tx/sponsored/submit`, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "X-API-Key": ENTERPRISE_API_KEY,
+    "Authorization": `Bearer ${userJwt}`,
+  },
+  body: JSON.stringify({ tx: signedTx }),
+}).then(r => r.json());
+```
+
+`POST /api/v2/tx/sponsored/submit` takes `{ "tx": "<holder-signed-cbor-hex>" }` and returns `{ "tx_hash": "<tx-hash>" }`. From there, register and monitor exactly as in [Transaction Handling](/docs/guides/developers/transactions) — the lifecycle after submission is identical.
+
+<Callout type="warn">
+A sponsored build is reserved against quota when it is built. It must be submitted before it expires, or the build is lost and must be rebuilt (and re-counted against quota).
+</Callout>
+
+## Error Contract
+
+Sponsorship adds a few failure modes on top of the standard transaction errors:
+
+| Status | Meaning |
+|--------|---------|
+| `402 Payment Required` | No matching sponsorship allocation, or quota is exhausted. Can also occur at submit time if quota ran out between build and submit. |
+| `400 Bad Request` | Caller supplied `sponsor_data` on a sponsored route, the `access-token/mint` receiver matched the sponsor address, or the submitted transaction was rejected. |
+| `404 Not Found` | No pending sponsored build exists for the submitted transaction. |
+| `409 Conflict` | The sponsored build was already submitted. |
+| `410 Gone` | The sponsored build expired — rebuild it. |
+| `502 Bad Gateway` | The sponsorship or submission service was unavailable. Safe to retry the build. |
+
+Treat `402` as the signal to surface an "out of sponsored capacity" state in your app, and `410` as "rebuild and retry."
+
+## Next Steps
+
+- [Transaction Handling](/docs/guides/developers/transactions) — The self-funded lifecycle and post-submit monitoring
+- [API Keys](/docs/guides/developers/api-keys) — Enterprise key provisioning
+- [Billing & Pricing](/docs/guides/developers/billing) — Tiers and quotas
+- [Error Handling](/docs/guides/developers/error-handling) — Recovery patterns

--- a/content/docs/guides/developers/transactions.mdx
+++ b/content/docs/guides/developers/transactions.mdx
@@ -105,6 +105,7 @@ These hooks abstract the manual fetch/sign/submit code shown above. See the [How
 
 ## Next Steps
 
+- [Sponsored Transactions](/docs/guides/developers/sponsored-transactions) — Let your organization pay blockchain fees on behalf of users (enterprise)
 - [Error Handling](/docs/guides/developers/error-handling) — Recovery patterns for failed transactions
 - [Transaction State Machine](/docs/protocol/v2/state-machine) — Deep dive into state transitions
 - [API Docs](https://preprod.api.andamio.io) — Full endpoint documentation (preprod)

--- a/content/docs/protocol/v2/state-machine/index.mdx
+++ b/content/docs/protocol/v2/state-machine/index.mdx
@@ -258,7 +258,7 @@ When a contributor commits to a task (`project_join`):
 
 Status progression: `DRAFT` → `SUBMITTED` → `ACCEPTED` or `REFUSED` → `REWARDED`
 
-> **Note**: The API previously returned a `COMMITTED` status between `DRAFT` and `SUBMITTED`. As of v2.1.1-rc12, the API normalizes `COMMITTED` to `SUBMITTED` at read time — commit and submit are the same action on-chain.
+> **Note**: Earlier API releases returned a `COMMITTED` status between `DRAFT` and `SUBMITTED`. The API now normalizes `COMMITTED` to `SUBMITTED` at read time — commit and submit are the same action on-chain.
 
 > **Note**: A contributor's first commit to a project also "joins" the project by minting a contributor token. Subsequent commits by the same contributor do not mint again. The state machine handles both cases transparently.
 

--- a/content/docs/protocol/v2/whats-new.mdx
+++ b/content/docs/protocol/v2/whats-new.mdx
@@ -153,4 +153,4 @@ Existing V1 users can migrate to V2 using the `move-global-state-v1-to-v2` trans
 
 ---
 
-*This page is updated as we document more V2 transactions. Last updated: December 2024*
+*This page is updated as we document more V2 transactions. Last updated: May 2026*

--- a/docs/plans/2026-04-06-001-feat-docs-audit-remediation-plan.md
+++ b/docs/plans/2026-04-06-001-feat-docs-audit-remediation-plan.md
@@ -477,3 +477,7 @@ Developers building on Andamio hit gaps when the docs don't reflect the current 
 - andamio-api `internal/config/config.yaml` — canonical tier/pricing configuration
 - andamio-app-v2 `docs/solutions/architecture/stripe-redirect-billing-integration-pattern.md` — billing implementation details
 - andamio-docs `docs/solutions/integration-issues/fumadocs-broken-directory-links.md` — Fumadocs navigation gotchas
+
+## Follow-up (2026-05-20)
+
+This plan was remediation, not prevention. The v2.3 audit (PR #16, 2026-05-19) found the same drift pattern had recurred — the `51f5b93` commit was already stale on merge because no gate ties docs sync to the release cycle. The recurring fix is captured in `docs/solutions/workflow-issues/docs-release-sync-drift-2026-05-20.md` (release-cycle hook + drift detector + scheduled audit). The drift detector (`npm run docs-drift`, `.claude/skills/audit-docs/`) is now implemented; the release-cycle hook is the next step.

--- a/docs/solutions/workflow-issues/docs-release-sync-drift-2026-05-20.md
+++ b/docs/solutions/workflow-issues/docs-release-sync-drift-2026-05-20.md
@@ -1,0 +1,176 @@
+---
+title: "Andamio docs site drifts from platform release cycle with no gate"
+date: 2026-05-20
+category: workflow-issues
+module: andamio-docs/release-sync
+problem_type: workflow_issue
+component: documentation
+severity: high
+applies_when:
+  - A new platform/API/CLI/devkit version ships and andamio-docs has no corresponding update PR
+  - A feature lands across multiple routes (e.g., enterprise sponsorship) without a docs entry
+  - Version-pinned references (CLI install lines, API version notes, state-machine versions) appear in MDX
+  - A prior "sync" commit lands without a recurring re-check scheduled
+  - CIP-30 / auth / JWT behavior changes ship in api or devkit PRs without a docs checklist
+tags:
+  - release-sync
+  - docs-drift
+  - andamio-docs
+  - devkit-v2.3
+  - version-pinning
+  - release-gate
+  - drift-detector
+  - audit-cadence
+---
+
+# Andamio docs site drifts from platform release cycle with no gate
+
+## Context
+
+The v2.3 documentation audit (PR #16, branch `feat/docs-sync-v2.3`) surfaced systemic drift between `andamio-docs` and shipped platform state. Concretely:
+
+- The CLI install example pinned `0.9.1` while `andamio-cli` had tagged `v0.12.1` — three minor versions behind.
+- The state-machine note still referenced API `v2.1.1-rc12` while the gateway had moved to `v2.3.5` — two release cycles ahead.
+- Enterprise sponsorship was live across 8 routes with **zero** developer-facing documentation.
+- CIP-30 developer login and the JWT lifetime cut + refresh-token flow (api#409 / PR#410) were undocumented despite being security-relevant.
+
+Most tellingly, the prior remediation commit `51f5b93` ("sync with API v2.1.4, CLI v0.10.2") was already stale at the moment it merged — the sync was written against a moving target with no gate to anchor it. The root cause is structural: nothing ties a docs sync to the release cycle, so sync happens by ad-hoc audit, and the audit itself lags.
+
+This is not a one-off. Prior sessions confirm the pattern (session history):
+
+- **April 6, 2026** — the `51f5b93` cycle ran a full `ce:plan`-driven remediation (16 requirements, 6 new pages, 5 updates) and explicitly acknowledged it was *remediation, not prevention*. No gate was put in place for the next cycle.
+- **May 8, 2026** — `andamio-api` cut v2.3.1, opened `chore/sync-v2.3.1-version-refs` (PR #427), tagged, deployed, and merged. The session ended with no corresponding check of `andamio-docs`. The release process has no docs-sync step.
+- **April 29, 2026** — the `fix/jwt-expiry-wallet-disconnect` session noted "CLAUDE.md polling-interval doc drift" and skipped it as "natural cleanup during A1 PR." Drift is normalized inside individual repos too.
+- **May 19, 2026** — the `andamio-cli` `apikey usage`/`profile` 401 incident: the gateway moved endpoints behind `developerJWTAuth` (v2.2→v2.3), the CLI didn't follow (PR #96). Same category — downstream surfaces don't automatically learn about behavioral changes.
+
+The April 6 plan worked for content but had no mechanism to signal when the next sync was needed. Version strings in MDX are passive drift indicators that don't self-report; they only surface when someone audits.
+
+## Guidance
+
+Adopt a layered approach. No single layer is sufficient — each catches a different failure mode. **Implement layer 2 first** — the drift detector pays off immediately against the current `andamio-docs` state without needing devkit workflow changes.
+
+### Layer 1 — Release-cycle hook (primary, once detector proves the signal)
+
+When a `devkit/docs/releases/vX.Y/RELEASE_REPORT.md` is finalized, mechanically generate a "Public docs delta" checklist from the report's `Developer-visible`, `User-requested endpoints`, and `Security` sections. The checklist gets appended to the release report and a matching docs PR is opened against `andamio-docs` as part of the release — not after it.
+
+Sketch (in devkit):
+
+```bash
+# devkit/scripts/emit-docs-delta.sh
+REPORT=docs/releases/v2.3/RELEASE_REPORT.md
+awk '/^## (Developer-visible|User-requested endpoints|Security)/,/^## /' "$REPORT" \
+  | grep -E '^- ' \
+  | sed 's/^- /- [ ] Docs: /' \
+  > docs/releases/v2.3/PUBLIC_DOCS_DELTA.md
+```
+
+The docs PR is a tick-through of the checklist. Trade-off: requires release authors to keep `RELEASE_REPORT.md` section headers consistent — already an internal convention worth holding.
+
+### Layer 2 — Drift detector (automated, between releases — build this first)
+
+A script that compares authoritative version sources against version strings in `content/docs/**/*.mdx`. Authoritative sources:
+
+- `devkit/VERSIONS` — `GATEWAY_TAG` (only this for public-docs purposes; ignore `DB_API_TAG`, `ATLAS_TAG`, `INDEXER_TAG`, `SIDECAR_TAG` — those are internal services excluded from public docs).
+- `git -C ~/projects/01-projects/andamio-cli describe --tags --abbrev=0` — current CLI tag.
+
+Sketch (run from `andamio-docs`):
+
+```bash
+# .claude/skills/audit-docs/detect-drift.sh
+CLI_LATEST=$(git -C ../andamio-cli describe --tags --abbrev=0)        # e.g. v0.12.1
+GATEWAY_LATEST=$(grep '^GATEWAY_TAG=' ../andamio-dev-kit-internal/VERSIONS | cut -d= -f2)
+
+# Find any CLI version string in docs that doesn't match latest
+grep -rEn 'andamio-cli@v?[0-9]+\.[0-9]+\.[0-9]+|VERSION=[0-9]+\.[0-9]+\.[0-9]+' content/docs \
+  | grep -v "${CLI_LATEST#v}" \
+  || echo "CLI versions: OK"
+
+# Find any API version pin in docs that doesn't match gateway
+grep -rEn 'v2\.[0-9]+\.[0-9]+(-rc[0-9]+)?' content/docs \
+  | grep -v "$GATEWAY_LATEST" \
+  || echo "Gateway versions: OK"
+```
+
+Output is a checklist, **not** a hard CI fail. Hard-failing CI on every version bump punishes the wrong moment; a checklist makes drift visible without blocking unrelated docs PRs. Add an allowlist (`docs/.drift-allowlist`) for intentional historical references (e.g., changelog entries).
+
+### Layer 3 — Scheduled audit (fallback)
+
+A quarterly `/audit-docs` skill invocation that diffs `devkit/plans/`, `devkit/notes/`, `devkit/docs/tx-flows/`, and recent `RELEASE_REPORT.md` files against current MDX. Useful when Layer 1 is skipped under release pressure and Layer 2 is silenced by allowlist creep. Cheap insurance, not the primary mechanism.
+
+### Scope constraint (all three layers)
+
+Drift checks must filter to the **developer-facing surface**: gateway routes + CLI commands/flags + public auth flows. Internal services (`db-api`, `atlas`, `andamioscan`, `sidecar`) appear in `VERSIONS` and `RELEASE_REPORT.md` but are intentionally excluded from public docs — the drift detector should pin to `GATEWAY_TAG` and CLI tags only.
+
+### Two-surface routing
+
+The public docs site has two surfaces with different audit owners (session history):
+
+- **Developer guides** (`content/docs/guides/developers/`) — operational knowledge: source field, safe refetch, billing, sponsorship. Owned by the release-sync workflow this doc defines.
+- **Protocol/transaction docs** (`content/docs/protocol/v2/transactions/`, `…/validators/`, `…/tokens/`) — owned by the existing `/v2-docs-audit` and `/transaction-audit` skills, which sync against Atlas swagger.
+
+A drift detector should route by file path, not by version string alone, so the right skill picks up each finding.
+
+### Don't mirror the schema layer
+
+The live API reference is served via Scalar from the API repo's `web/public/reference.html` against the generated `openapi/swagger.json` at `https://preprod.api.andamio.io/reference` (session history). Public docs should document concepts, flows, and developer patterns — not mirror request/response schemas, which the live reference always serves current. The drift detector should ignore schema-layer drift; only flag conceptual, version-pinned, or flow-level drift.
+
+### Kill-switched features
+
+When a behavior change is behind a deploy-gated kill switch (as with api#409 CIP-30 login), document the behavior change but point to the live API reference for exact endpoint paths rather than hardcoding them. The v2.3 audit applied this pattern in `developer-accounts.mdx`. Make it a standing rule, not a one-off judgment call.
+
+## Why This Matters
+
+Drift in public docs is not a cosmetic problem — it's an adoption tax. Enterprise sponsorship shipped live across 8 routes with zero developer documentation; any external developer evaluating Andamio at that moment would have concluded the feature didn't exist. CIP-30 login and short JWT lifetimes are security-relevant; missing docs there don't just slow integration, they invite incorrect implementations.
+
+The `51f5b93` pattern — "sync" commits that are already stale on merge — is the diagnostic signature of a missing gate: a human heroically catches up, the catch-up itself ages out before the next sync, and the cycle repeats. The May 8 v2.3.1 sync PR confirms the gap is in the release process itself: tag, deploy, merge, finish — with no step that touches the docs repo.
+
+Each release without a gate compounds drift (linearly in shipped features, super-linearly in developer confusion). Each release with a gate compounds confidence: external developers learn that the docs they're reading describe the system they're calling, and the team learns that "ship" includes "documented." That trust is the actual product surface.
+
+## When to Apply
+
+- A `devkit/docs/releases/vX.Y/RELEASE_REPORT.md` is being finalized — generate the docs delta checklist as part of finalization.
+- A sibling repo cuts a tag bump that crosses a minor version (e.g., `GATEWAY_TAG` moves from `v2.2.x` to `v2.3.0`, or `andamio-cli` moves from `v0.11.x` to `v0.12.0`).
+- A new public-facing endpoint, CLI flag, or auth path ships — even outside a numbered release.
+- Any PR titled `docs: sync …` opens — pair it with a generated delta checklist rather than free-form audit notes.
+- Before publishing a `/guide-pipeline` status update — run the drift detector so the status reflects current reality.
+- Quarterly, as a fallback `/audit-docs` invocation, even if no release triggered it.
+
+## Examples
+
+**Before (v2.3 audit, PR #16):** ad-hoc workflow. Started from a manual read of `devkit/plans/`, `notes/`, and `RELEASE_REPORT.md`. Produced an audit document, then ~9 file edits across `content/docs/`. Several changes (e.g., exact CIP-30 endpoint paths) were unverifiable from docs alone because a deploy-gated kill switch made the public surface ambiguous at audit time — the audit had to make judgment calls without a feedback loop back to the release author. Total cost: a full session of human attention, and the result was a point-in-time snapshot that started drifting again immediately.
+
+**After (proposed):** the devkit release author finalizes `docs/releases/v2.3/RELEASE_REPORT.md`. A hook (or a manual `scripts/emit-docs-delta.sh` run) emits `docs/releases/v2.3/PUBLIC_DOCS_DELTA.md`:
+
+```markdown
+# Public docs delta — v2.3
+
+- [ ] Docs: CIP-30 developer login flow (api#409)
+- [ ] Docs: JWT lifetime cut + refresh-token rotation (PR#410)
+- [ ] Docs: enterprise sponsorship — 8 routes + /tx/sponsored/submit
+- [ ] Docs: update CLI install example to v0.12.1
+- [ ] Docs: bump state-machine note API pin from v2.1.1-rc12 to v2.3.5
+- [ ] Docs: get-qualified contributors endpoint + status semantics
+```
+
+The docs PR against `andamio-docs` is a tick-through of that file. Between releases, the drift detector catches anything the checklist missed:
+
+```text
+$ ./.claude/skills/audit-docs/detect-drift.sh
+content/docs/guides/developers/cli/installation.mdx:20: VERSION=0.9.1            # expected 0.12.1
+content/docs/protocol/v2/state-machine/index.mdx:261: v2.1.1-rc12                # expected v2.3.5
+```
+
+**Implementation order:**
+
+1. Build the drift detector first — it pays off against current `andamio-docs` state immediately.
+2. Add the release-cycle hook second, once the detector has proven the signal is useful.
+3. Treat the scheduled audit as a backstop, not a primary mechanism.
+
+## Related
+
+- [PR #16 — docs: sync developer docs with v2.3 platform state](https://github.com/Andamio-Platform/andamio-docs/pull/16) — the triggering audit.
+- `docs/plans/2026-04-06-001-feat-docs-audit-remediation-plan.md` — prior remediation cycle; this learning generalizes its lesson.
+- `.claude/skills/transaction-audit/SKILL.md` — domain-specific instance of release-cycle drift (Atlas swagger → V2 transaction YAML); should cross-link as the V2-transactions-only instance of this practice.
+- `.claude/skills/v2-docs-audit/SKILL.md` — coverage tracking for V2 transaction MDX; same family, narrower scope.
+- `.claude/skills/guide-pipeline/SKILL.md` "Cross-Repo Sync" section — proves the cross-repo tracker pattern; scope is onboarding guides + UX readiness.
+- `~/projects/01-projects/andamio-dev-kit-internal/docs/releases/v2.3/RELEASE_REPORT.md` — the source-of-truth artifact a release-cycle hook would consume.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "dev": "next dev --turbo",
     "start": "next start",
-    "docs-coverage": "npx tsx scripts/docs-coverage-check.ts"
+    "docs-coverage": "npx tsx scripts/docs-coverage-check.ts",
+    "docs-drift": ".claude/skills/audit-docs/detect-drift.sh"
   },
   "dependencies": {
     "@content-collections/core": "^0.14.2",


### PR DESCRIPTION
Two layers in one PR: content sync (the symptom fix) + a recurring drift detector and captured workflow learning (the structural fix so v2.4 doesn't repeat the pattern). Public docs cover only the developer-facing gateway + CLI surface; internal services (db-api, atlas, andamioscan, sidecar) are intentionally excluded.

## Part 1 — Content sync to v2.3 platform state

**New: Sponsored Transactions guide** (`guides/developers/sponsored-transactions.mdx`)
- Largest gap: enterprise transaction sponsorship shipped across the platform but had zero developer docs (glossary entry only).
- Covers the 8 sponsored routes, route- vs course-scoped quota, the two response shapes (direct-submit vs holder-signed), `POST /api/v2/tx/sponsored/submit`, and the `402/400/404/409/410/502` error contract — at the gateway boundary, no internal-service naming.

**Version / correctness sync**
- CLI install example `0.9.1` → `0.12.1` (current release; docs were 3 minor versions behind).
- Dropped misleading `v2.1.1-rc12` pin on the `COMMITTED→SUBMITTED` note (gateway is now v2.3.5).
- Documented `GET /v2/project/manager/contributors/get-qualified` + `ok` / `no_prerequisites_configured` status semantics.
- Refreshed the protocol `whats-new` last-updated stamp.

**Auth (api#409 / PR#410)**
- Added CIP-30 wallet-signature developer login + refresh-token rotation note to Developer Accounts.
- Stopped asserting a fixed 24h JWT window in user auth; lifetimes shortened — docs now direct devs to read `expires_at`/`exp`. Exact new endpoint schemas point to the live API reference (the new login path is behind a deploy-gated kill switch, so paths weren't hardcoded).

## Part 2 — Drift detector + captured workflow practice

The v2.3 audit was the symptom. The structural cause was: nothing ties docs sync to the release cycle, so the prior remediation commit `51f5b93` ("sync with API v2.1.4, CLI v0.10.2") was already stale on merge. Session history confirmed the pattern is recurring (April 6 plan-driven cycle; May 8 `andamio-api` v2.3.1 sync PR ended with no docs check; April 29 polling-interval drift normalized as "natural cleanup"; May 19 CLI `apikey usage` 401 — same category).

**New: `npm run docs-drift`** (`.claude/skills/audit-docs/detect-drift.sh`)
- Reads `GATEWAY_TAG` from devkit `VERSIONS` and the latest `andamio-cli` git tag.
- Greps `content/docs/guides/developers/**`, `state-machine/**`, `getting-started.mdx`, `reference/**`.
- Excludes `protocol/v2/transactions|validators|tokens/**` (owned by `/v2-docs-audit`, `/transaction-audit`), pioneers, whats-new, glossary.
- Informational by default; `--strict` makes it exit 1 on drift for CI.
- Allowlist file (`.drift-allowlist`) for intentional historical references.
- Verified: clean tree → "No drift detected. ✓"; inject `VERSION=0.9.1` → caught with file:line + expected vs actual, `--strict` exit 1.

**New compound learning** (`docs/solutions/workflow-issues/docs-release-sync-drift-2026-05-20.md`)
Captures the layered fix: release-cycle hook (Layer 1, devkit-side, future) + drift detector (Layer 2, shipped here) + scheduled audit (Layer 3, fallback). Session-history findings tagged inline.

**Cross-links** added to the narrower precursors so future readers find the umbrella practice:
- `docs/plans/2026-04-06-001-feat-docs-audit-remediation-plan.md` (Follow-up section)
- `.claude/skills/{transaction-audit,v2-docs-audit,guide-pipeline}/SKILL.md`

**Discoverability** — `.claude/CLAUDE.md` now surfaces `docs/solutions/` and the `docs-drift` command.

## Not done (deliberately)
- Pricing/commission rewrite: the `fee_tier`→`fee_rate` change is internal gateway behavior; no existing public doc claims developers set fee tiers, and the service-fee tables remain accurate. No speculative content added.
- `credential-holders` query endpoint: served outside the gateway per devkit `SYSTEM_REFERENCE.md`; public-API exposure unconfirmed, so left out under the no-internal-services constraint.
- Layer 1 release-cycle hook in devkit: blocked here on a devkit PR; tracked as next step in the compound doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)