### PR TITLE
Tidy docs nav: fold papers under Get to Know Andamio, shorten Light Paper

### DIFF
--- a/content/docs/light-paper.mdx
+++ b/content/docs/light-paper.mdx
@@ -1,9 +1,9 @@
 ---
-title: Andamio Light Paper
+title: Light Paper
 description: A short read on what Andamio is, why it exists, and how credentials build trust
 ---
 
-# Andamio Light Paper
+# Light Paper
 
 > **Coming soon.** This one is being written now.
 

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -9,7 +9,6 @@
         "[Preprod API](https://preprod.api.andamio.io)",
         "--- Get to Know Andamio ---",
         "guides",
-        "--- The Andamio Papers ---",
         "light-paper",
         "andamio-issuer",
         "building-on-andamio",


### PR DESCRIPTION
Follow-up to #18.

- Removes the **The Andamio Papers** subheading; the three papers (Light Paper, Andamio Issuer, Building on Andamio) now live under the existing **Get to Know Andamio** section with the platform guides.
- Shortens the umbrella's nav label from **Andamio Light Paper** to **Light Paper**.