### PR TITLE
Clean up navigation + consolidate API doc links

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -32,7 +32,7 @@ export default function HomePage() {
           Get Started
         </Link>
         <Link
-          href="https://mainnet.api.andamio.io/reference"
+          href="https://api.andamio.io"
           className="inline-flex items-center rounded-lg border border-border px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent"
         >
           API Reference

--- a/app/layout.config.tsx
+++ b/app/layout.config.tsx
@@ -35,9 +35,5 @@ export const baseOptions: BaseLayoutProps = {
       text: "Guides",
       url: "/docs/guides",
     },
-    {
-      text: "API Reference",
-      url: "https://mainnet.api.andamio.io/reference",
-    },
   ],
 };

--- a/content/docs/demo.mdx
+++ b/content/docs/demo.mdx
@@ -35,11 +35,8 @@ A REST API that abstracts Cardano complexity. Non-Cardano developers can build c
   <Card title="API Quickstart" href="/docs/guides/developers/api-quickstart" icon={<Code />}>
     Make your first API call in 5 minutes
   </Card>
-  <Card title="Mainnet API Reference" href="https://mainnet.api.andamio.io" icon={<ExternalLink />}>
-    Full endpoint documentation (production)
-  </Card>
-  <Card title="Preprod API Reference" href="https://preprod.api.andamio.io" icon={<ExternalLink />}>
-    Full endpoint documentation (development)
+  <Card title="API Reference" href="https://api.andamio.io" icon={<ExternalLink />}>
+    Full endpoint documentation
   </Card>
 </Cards>
 

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -124,7 +124,7 @@ These docs use **preprod** (Cardano testnet) for safe development. When your app
   <Card title="Environment Reference" href="/docs/reference/environments">
     All environment configurations for dev, staging, and production
   </Card>
-  <Card title="API Reference" href="https://preprod.api.andamio.io/api/v1/docs/index.html">
+  <Card title="API Reference" href="https://api.andamio.io">
     Full endpoint documentation
   </Card>
 </Cards>

--- a/content/docs/guides/developers/api-concepts.mdx
+++ b/content/docs/guides/developers/api-concepts.mdx
@@ -48,7 +48,7 @@ The gateway provides 27 endpoints that combine DB and Andamioscan data into unif
 - `POST /v2/project/user/projects/list` — Projects with merged on-chain state
 - Role-specific views for owners, teachers, students, managers, and contributors
 
-See the [API Reference](https://preprod.api.andamio.io/reference) for the complete list.
+See the [API Reference](https://api.andamio.io) for the complete list.
 
 ## Safe Refetch Timing
 
@@ -157,4 +157,4 @@ The `no_prerequisites_configured` status lets you distinguish "no one qualifies 
 
 - [Transaction Handling](/docs/guides/developers/transactions) — The full transaction lifecycle
 - [Error Handling](/docs/guides/developers/error-handling) — Failure modes and recovery
-- [API Reference](https://preprod.api.andamio.io/reference) — Complete endpoint documentation
+- [API Reference](https://api.andamio.io) — Complete endpoint documentation

--- a/content/docs/guides/developers/api-integration.mdx
+++ b/content/docs/guides/developers/api-integration.mdx
@@ -3,7 +3,7 @@ title: API Integration
 description: API setup and making requests to the Andamio Gateway
 ---
 
-> **API Reference**: [Preprod API Docs](https://preprod.api.andamio.io) for endpoint schemas. For production, use `mainnet.api.andamio.io`.
+> **API Reference**: [API Docs](https://api.andamio.io) for endpoint schemas. For production, use `mainnet.api.andamio.io`.
 
 ## Authentication Headers
 
@@ -60,7 +60,7 @@ The Andamio Gateway provides approximately 120 endpoints across these categories
 | Token Registry | `/api/v2/token/*` | Native asset registration and listing | |
 | Dashboard | `/api/v2/user/dashboard` | Consolidated user view (courses + projects) | |
 
-For the complete endpoint reference with request/response schemas, see the [Preprod API Docs](https://preprod.api.andamio.io/reference).
+For the complete endpoint reference with request/response schemas, see the [API Docs](https://api.andamio.io).
 
 For transaction building and submission, see [Transaction Handling](/docs/guides/developers/transactions).
 
@@ -117,4 +117,4 @@ See [Error Handling](/docs/guides/developers/error-handling) for recovery patter
 - [API Concepts](/docs/guides/developers/api-concepts) — Source field, safe refetch timing, event queries
 - [Transaction Handling](/docs/guides/developers/transactions) — Build, sign, and submit transactions
 - [Error Handling](/docs/guides/developers/error-handling) — Recovery patterns and failure modes
-- [Preprod API Docs](https://preprod.api.andamio.io) — Full endpoint reference
+- [API Docs](https://api.andamio.io) — Full endpoint reference

--- a/content/docs/guides/developers/api-quickstart.mdx
+++ b/content/docs/guides/developers/api-quickstart.mdx
@@ -114,4 +114,4 @@ See [Authentication](/docs/guides/developers/authentication) for the full JWT fl
 
 - **[Authentication](/docs/guides/developers/authentication)** — User login with wallet signatures
 - **[Transaction Handling](/docs/guides/developers/transactions)** — Build, sign, and submit transactions
-- **[API Reference](https://preprod.api.andamio.io/api/v2/docs/index.html)** — Full endpoint documentation
+- **[API Reference](https://api.andamio.io)** — Full endpoint documentation

--- a/content/docs/guides/developers/developer-accounts.mdx
+++ b/content/docs/guides/developers/developer-accounts.mdx
@@ -68,7 +68,7 @@ Developers can also authenticate with a CIP-30 wallet signature instead of a pas
 
 Developer JWT lifetimes are short-lived and paired with refresh-token rotation: exchange a refresh token for a new Developer JWT rather than re-running the full login when the JWT expires. Always read `exp` (or the returned `expires_at`) rather than assuming a fixed lifetime — do not hardcode an expiry window.
 
-See the [live API reference](https://preprod.api.andamio.io/reference) for the exact wallet-login and refresh endpoint schemas, which are versioned with the API.
+See the [live API reference](https://api.andamio.io) for the exact wallet-login and refresh endpoint schemas, which are versioned with the API.
 
 ### Developer JWT Claims
 

--- a/content/docs/guides/developers/error-handling.mdx
+++ b/content/docs/guides/developers/error-handling.mdx
@@ -19,7 +19,7 @@ Transactions can reach three terminal states:
 
 | Code | Meaning | Resolution |
 |------|---------|------------|
-| `400` | Bad request / validation error | Check request body against [API Reference](https://preprod.api.andamio.io/reference) |
+| `400` | Bad request / validation error | Check request body against [API Reference](https://api.andamio.io) |
 | `401` | Invalid or expired JWT | Re-authenticate user via wallet signature |
 | `403` | Insufficient permissions | User lacks required role (e.g., not a teacher) |
 | `409` | Duplicate registration | Transaction already registered — safe to ignore |
@@ -215,4 +215,4 @@ curl https://andamioscan.io/api/tx/$TX_HASH
 - [API Concepts](/docs/guides/developers/api-concepts) — Safe refetch timing and the source field
 - [API Integration](/docs/guides/developers/api-integration) — Complete transaction flow
 - [Transaction State Machine](/docs/protocol/v2/state-machine) — State transition details
-- [API Reference](https://preprod.api.andamio.io/reference) — Endpoint documentation
+- [API Reference](https://api.andamio.io) — Endpoint documentation

--- a/content/docs/guides/developers/index.mdx
+++ b/content/docs/guides/developers/index.mdx
@@ -42,7 +42,7 @@ After setup, continue with **[Your First Andamio App](/docs/guides/developers/fi
 
 ## Reference
 
-- **[Preprod API Docs](https://preprod.api.andamio.io)** — Full endpoint documentation
+- **[API Docs](https://api.andamio.io)** — Full endpoint documentation
 - **[Protocol](/docs/protocol)** — On-chain architecture and state machines
 - **[SDK](/docs/sdk)** — NPM packages for Andamio development
 - **[App Template](https://github.com/Andamio-Platform/andamio-app-template)** — Fork and build

--- a/content/docs/guides/developers/transactions.mdx
+++ b/content/docs/guides/developers/transactions.mdx
@@ -106,5 +106,5 @@ These hooks abstract the manual fetch/sign/submit code shown above. See the [How
 - [Sponsored Transactions](/docs/guides/developers/sponsored-transactions) — Let your organization pay blockchain fees on behalf of users (enterprise)
 - [Error Handling](/docs/guides/developers/error-handling) — Recovery patterns for failed transactions
 - [Transaction State Machine](/docs/protocol/v2/state-machine) — Deep dive into state transitions
-- [API Docs](https://preprod.api.andamio.io) — Full endpoint documentation (preprod)
+- [API Docs](https://api.andamio.io) — Full endpoint documentation
 - [App Template](https://github.com/Andamio-Platform/andamio-app-template) — Production-ready starter with hooks

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -36,11 +36,8 @@ To see what others are building, join [Andamio Pioneers](https://discord.gg/wfGr
 ## Reference
 
 <Cards>
-  <Card title="Preprod API" href="https://preprod.api.andamio.io">
-    Endpoint documentation for development
-  </Card>
-  <Card title="Mainnet API" href="https://mainnet.api.andamio.io">
-    Endpoint documentation for production
+  <Card title="API Reference" href="https://api.andamio.io">
+    Full endpoint documentation
   </Card>
   <Card title="SDK" href="/docs/sdk">
     TypeScript packages for transaction building

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -20,17 +20,14 @@
         "--- Reference ---",
         "reference",
         "[Protocol internals →](/docs/protocol)",
-        "--- Resources ---",
         "repositories",
         "pioneers",
         "demo",
         "--- External ---",
-        "[Mainnet API](https://mainnet.api.andamio.io)",
-        "[Preprod API](https://preprod.api.andamio.io)",
-        "[API Reference](https://mainnet.api.andamio.io/reference)",
+        "[API Reference](https://api.andamio.io)",
         "[Andamio SDK](https://sdk.andamio.io/)",
-        "[andamio.io](https://andamio.io)",
         "[Andamio App](https://mainnet.app.andamio.io)",
+        "[andamio.io](https://andamio.io)",
         "[GitHub](https://github.com/Andamio-Platform)"
     ]
 }

--- a/content/docs/pioneers/index.mdx
+++ b/content/docs/pioneers/index.mdx
@@ -31,7 +31,7 @@ Weekly sessions on Wednesdays at **14:00 UTC** and **20:00 UTC**. We build in pu
 |----------|------|
 | App Template | [GitHub](https://github.com/Andamio-Platform/andamio-app-template) |
 | Submit Issues | [GitHub Issues](https://github.com/Andamio-Platform/andamio-app-template/issues) |
-| API Docs | [Preprod Gateway](https://preprod.api.andamio.io/api/v1/docs/index.html) |
+| API Docs | [API Reference](https://api.andamio.io) |
 | Environment Reference | [All env vars and URLs](/docs/reference/environments) |
 
 ## Philosophy

--- a/content/docs/pioneers/live-coding/archive/sessions/session-001.mdx
+++ b/content/docs/pioneers/live-coding/archive/sessions/session-001.mdx
@@ -60,9 +60,9 @@ When a course exists on-chain but not in the database (or vice versa), which is 
 
 - [Full Transcript](./transcripts/202512111500-transcript.md)
 - [T3 App Template](https://github.com/Andamio-Platform/andamio-app-v2)
-- [Andamio API Gateway Docs](https://preprod.api.andamio.io/api/v1/docs/index.html)
+- [Andamio API Gateway Docs](https://api.andamio.io)
 
-*Note: The three separate APIs (Andamioscan, Atlas TX, DB API) referenced during this session have since been unified behind the [Andamio API Gateway](https://preprod.api.andamio.io/api/v1/docs/index.html).*
+*Note: The three separate APIs (Andamioscan, Atlas TX, DB API) referenced during this session have since been unified behind the [Andamio API Gateway](https://api.andamio.io).*
 
 ## Next Session
 

--- a/content/docs/protocol/v2/transactions/index.mdx
+++ b/content/docs/protocol/v2/transactions/index.mdx
@@ -77,4 +77,4 @@ Detailed technical reference for each V2 transaction — inputs, outputs, mintin
 ## Related APIs
 
 - **[Andamioscan API](https://preprod.andamioscan.io/api)** - Query indexed transaction data and on-chain state
-- **[API Docs](https://mainnet.api.andamio.io)** - Full Andamio API documentation
+- **[API Docs](https://api.andamio.io)** - Full Andamio API documentation


### PR DESCRIPTION
Addresses the sidebar and the scattered API-documentation links.

## Sidebar
- **Removed "API Reference" from the top featured links** — it's an external link, so it now sits in the External group at the bottom.
- **Merged the bottom three groups into two:**
  - **Reference** (internal): Reference, Protocol internals →, Repositories, Andamio Pioneers, Live Demo
  - **External** (outbound): API Reference, Andamio SDK, Andamio App, andamio.io, GitHub
- **Collapsed three duplicate API links** (Mainnet API / Preprod API / API Reference) into a single **API Reference → api.andamio.io**.

## API documentation links → api.andamio.io
Every "API Reference" / "API Docs" *link* now points to the single canonical `api.andamio.io` (no mainnet/preprod prefix): home CTA, sidebar, and links across the guides, `index`, `demo`, `transactions`, and `pioneers` pages. Network-specific link text was relabeled ("Preprod API Docs" → "API Docs", etc.).

## Intentionally left as-is: functional URLs
Per the agreed scope, environment-specific URLs that are **operational, not doc links** were preserved — code samples (`const API_URL`), env vars (`NEXT_PUBLIC_ANDAMIO_GATEWAY_URL`), `curl`/health examples, and the Preprod-vs-Production tables in `environments.mdx` and the CLI guides. The preprod→mainnet progression is part of onboarding, and `api.andamio.io` is the docs portal, not a network-specific gateway.

## Verification
Dev server: sidebar renders the two new groups with a single API Reference link and no top API Reference (screenshots confirmed). All edited pages (`/docs`, `/docs/demo`, `/docs/getting-started`, `/docs/guides/developers/api-integration`, `/docs/pioneers`) return 200. Audited every remaining `mainnet/preprod.api` reference — all are functional code/env/curl/table values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)