### PR TITLE
Front door + Andamio Issuer section scaffold

### DIFF
--- a/content/docs/andamio-issuer.mdx
+++ b/content/docs/andamio-issuer.mdx
@@ -1,8 +1,0 @@
----
-title: Andamio Issuer
-description: Composable credentials for certification and partner programs
----
-
-> **Coming soon.**
-
-For organizations that run a credentialing program: how Andamio turns credentials from dead ends into building blocks that others can verify and build on.

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -3,52 +3,51 @@ title: Home
 icon: House
 ---
 
-Andamio is an open credentialing protocol: a way for groups of people to issue, earn, and verify proof of real work. Anyone can issue a credential, and one credential can be a prerequisite for earning another, so credentials compose into learning paths, permissions, and access rules across applications.
+Andamio is a credentialing solution: a way for groups of people to issue, earn, and verify proof of real work. Credentials live on public infrastructure, the Cardano blockchain, which keeps them permanent and independently verifiable, and lets them outlast the apps that issue them.
 
-Credentials live on public infrastructure, the Cardano blockchain, which keeps them permanent and tamper-proof and lets them outlast the apps that issue them. You can build on Andamio without touching the blockchain, or work directly with the on-chain protocol.
+There are two ways to build with Andamio, plus a live app to see it in action.
 
 <Cards>
-  <Card title="Issue credentials" href="/docs/andamio-issuer">
-    No-code issuance for organizations.
+  <Card title="Andamio API" href="/docs/getting-started">
+    The developer product. Read, mint, and gate credentials in your own app or system.
   </Card>
-  <Card title="Build with the API" href="/docs/getting-started">
-    Read, mint, and gate credentials in your own app.
+  <Card title="Andamio Issuer" href="/docs/issuer">
+    Low-code credentialing for organizations. Add verifiable credentials to programs you already run, with no wallets or tokens to manage.
   </Card>
-  <Card title="Use the app" href="https://app.andamio.io">
-    Earn credentials, take courses, and build a verifiable portfolio.
+  <Card title="Explore the app" href="https://app.andamio.io">
+    Take a course, complete work, and earn a credential. Built entirely on the Andamio API.
   </Card>
 </Cards>
 
-## What makes Andamio different
+## Two products, one protocol
 
-**Open.** Anyone can issue, not just approved institutions.
+**Andamio API** wraps the on-chain protocol into endpoints you build on. Most developers work at this level; you can also transact against the smart contracts directly. See [Building on Andamio](/docs/building-on-andamio).
 
-**Persistent.** Credentials are permanently held by the people who earn them, and they outlast the apps that issued them.
+**Andamio Issuer** is built on the API and abstracts the chain away entirely. It adds a verifiable credential layer to the systems an organization already runs, with no wallets or tokens for anyone to learn.
 
-**Composable.** Any issuer's credentials can be prerequisites for new ones.
+The **app** at [app.andamio.io](https://app.andamio.io) is a reference implementation on the API, open to anyone who wants to explore.
 
-**Private.** A credential's proof is public and verifiable; the evidence behind it stays yours.
+## What makes an Andamio credential different
 
-**Functional.** Use credentials to unlock funds, governance, and access, not just to signal.
+**Persistent.** Immutable and stored on public infrastructure no single company owns. A credential outlives whoever issued it.
+
+**Composable.** One credential can be required before someone earns the next, so credentials build on each other instead of piling up.
+
+**Useful.** Machine-readable. Software can verify that someone holds a credential and act on it: gate access, unlock the next step, or drive what an app does.
+
+**Private.** The proof is public and verifiable; the evidence behind it stays with the person who earned it.
+
+**Open.** Anyone can issue. A credential makes no claim about its own value; value comes from use.
+
+**Owned by the earner.** It lives with the person who earned it, not in the issuer's system, and they can carry it anywhere it is useful.
 
 To see what others are building, join [Andamio Pioneers](https://discord.gg/wfGrgJJheS).
 
-## Reference
-
-<Cards>
-  <Card title="API Reference" href="https://api.andamio.io">
-    Full endpoint documentation
-  </Card>
-  <Card title="SDK" href="/docs/sdk">
-    TypeScript packages for transaction building
-  </Card>
-</Cards>
-
-## Go Deeper
+## Go deeper
 
 <Cards>
   <Card title="Light Paper" href="/docs/light-paper">
-    What Andamio is and why it exists (coming soon)
+    What Andamio is and the design decisions behind it
   </Card>
   <Card title="Glossary" href="/docs/glossary">
     Key terms and concepts

--- a/content/docs/issuer/how-it-works.mdx
+++ b/content/docs/issuer/how-it-works.mdx
@@ -1,0 +1,44 @@
+---
+title: How it works
+description: The design decisions that make an Andamio credential a building block
+---
+
+<Callout type="info">
+  Scaffold in progress. The model below is stable; worked examples and screenshots will follow as the product firms up.
+</Callout>
+
+An Andamio credential behaves differently from a badge because of a few deliberate design decisions. Each one follows from anchoring credentials on a public ledger instead of inside a single company's database.
+
+## The credential model
+
+### It outlives whoever issued it
+
+The credential is immutable and stored on public infrastructure that no single company owns. It cannot be altered after the fact, and it does not disappear when a vendor or contract ends. You are not locked in, and neither are the people you credential.
+
+### It can build on other credentials
+
+A credential can be required before someone takes on the work that earns another, so what someone holds opens the door to what comes next.
+
+<Callout type="warn">
+  Cross-organization prerequisite enforcement (a credential from one issuer gating another issuer's program automatically, on-chain) is on the roadmap and not yet a shipped capability. This page will state precisely what is enforced today once that line is settled.
+</Callout>
+
+### Software can act on it
+
+The credential is machine-readable. An application can check that someone holds it and gate access on that, unlock the next step, or drive what happens next. It stops being something to look at and becomes something your systems use.
+
+### Proof is public; evidence is private
+
+Anyone can verify that a credential is real, while the work behind it stays with the person who earned it. This is how a diploma works: the credential is public, the exam papers are not. Andamio puts a hash of the evidence on-chain; the evidence itself never leaves your control.
+
+### You own what it means
+
+The barrier to issue is low, and the credential makes no claim about its own value. You define what it certifies; its value comes from the track record it earns once it is in the world. Andamio provides the issuance infrastructure; the meaning is yours.
+
+### The earner keeps it
+
+The credential lives with the person who earned it, not in your system, and they can carry it anywhere it is useful, even if they leave your program.
+
+## No blockchain to learn
+
+Issuer covers the chain entirely. Transactions are sponsored, so the people you credential never hold ADA or manage a wallet. From your side, you call an API; from their side, they earn a credential. The ledger is invisible to both.

--- a/content/docs/issuer/index.mdx
+++ b/content/docs/issuer/index.mdx
@@ -1,0 +1,51 @@
+---
+title: Andamio Issuer
+description: Low-code, verifiable credentials for the systems you already run
+---
+
+<Callout type="info">
+  Andamio Issuer is in active development. This section is a scaffold: the shape is settling, and detailed guides will land as the product firms up.
+</Callout>
+
+Andamio Issuer adds a verifiable credential layer on top of the programs your organization already runs. It is built on the [Andamio API](/docs/getting-started) and abstracts the blockchain away entirely: no wallets, no tokens, nothing new for you or the people you credential to learn.
+
+You get what a public ledger guarantees, a credential you control that anyone can verify, without anyone having to understand the chain underneath.
+
+## Who it's for
+
+Organizations that issue credentials and need them to mean something to whoever relies on them: an employer, a partner, or their own team. If you run a certification program, a training track, or a partner program today, Issuer turns the badges you hand out into credentials your systems, and others, can act on.
+
+## Why it's different from a badge
+
+A typical digital badge is a picture in a vendor's database. It can be changed, switched off, or lost, and most badges carry no data a system can read. An Andamio credential is the opposite:
+
+<Cards>
+  <Card title="Persistent" href="/docs/issuer/how-it-works">
+    Immutable and on public infrastructure. It outlives whoever issued it.
+  </Card>
+  <Card title="Useful" href="/docs/issuer/how-it-works">
+    Machine-readable. Your systems can verify it and act on it.
+  </Card>
+  <Card title="Private" href="/docs/issuer/how-it-works">
+    Proof is public and verifiable; the work behind it stays private.
+  </Card>
+  <Card title="Owned by the earner" href="/docs/issuer/how-it-works">
+    It belongs to the person who earned it, and travels with them.
+  </Card>
+</Cards>
+
+[How it works](/docs/issuer/how-it-works) walks through the full credential model.
+
+## Get started
+
+<Cards>
+  <Card title="Quickstart" href="/docs/issuer/quickstart">
+    Issue your first credential (coming soon)
+  </Card>
+  <Card title="Integrate via API" href="/docs/issuer/integrate">
+    The Issuer API surface and how it plugs into your systems
+  </Card>
+  <Card title="Pricing" href="https://www.andamio.io/pricing">
+    What each plan includes
+  </Card>
+</Cards>

--- a/content/docs/issuer/integrate.mdx
+++ b/content/docs/issuer/integrate.mdx
@@ -1,0 +1,33 @@
+---
+title: Integrate via API
+description: How Andamio Issuer plugs into the systems you already run
+---
+
+<Callout type="info">
+  Preview. The Issuer API surface is taking shape: the write plane is live on preprod and the read-plane endpoint list is locked, with response payloads still in progress. Endpoint details and schemas will be published here as they settle.
+</Callout>
+
+Andamio Issuer exposes a single, versioned API surface that you call from the systems you already run. It builds and submits the on-chain transactions for you, so your integration is ordinary REST: you make a request, Andamio handles the chain.
+
+## The shape
+
+**One namespace: `/issuer/v1/`.** Two kinds of endpoint:
+
+- **Write (`POST`)** builds a sponsored transaction that Andamio signs, sponsors, and submits on the caller's behalf. No wallets, no ADA, no signing on your side.
+- **Read (`GET`)** returns on-chain data, scoped server-side to the caller.
+
+**Authentication.** The tenant is your organization, identified by an `X-API-Key`. The caller is the authenticated person within it, acting in one of four roles: User, Admin, Teacher, or Learner.
+
+## What you can do
+
+The write plane covers the full credential lifecycle: create user accounts, create courses, manage teachers, define and remove credentials, submit and approve evidence, and claim earned credentials.
+
+The read plane covers the data you build on: course catalogs and structure, teachers and learners, and per-person views of the credentials someone holds, their submissions, and the reviews awaiting them.
+
+## How it relates to the Andamio API
+
+Issuer is a higher-level surface built on the [Andamio API](/docs/getting-started). The API gives developers the full protocol; Issuer narrows it to the credentialing job and removes the blockchain entirely. If you want lower-level control or are building something beyond credential issuance, build on the API directly.
+
+<Callout type="info">
+  Want early access or have integration questions? Reach out via [Andamio Pioneers](https://discord.gg/wfGrgJJheS).
+</Callout>

--- a/content/docs/issuer/meta.json
+++ b/content/docs/issuer/meta.json
@@ -1,0 +1,10 @@
+{
+    "title": "Andamio Issuer",
+    "icon": "BadgeCheck",
+    "pages": [
+        "index",
+        "how-it-works",
+        "quickstart",
+        "integrate"
+    ]
+}

--- a/content/docs/issuer/quickstart.mdx
+++ b/content/docs/issuer/quickstart.mdx
@@ -1,0 +1,17 @@
+---
+title: Quickstart
+description: Issue your first credential with Andamio Issuer
+---
+
+<Callout type="info">
+  Coming soon. The Issuer quickstart will land once the onboarding flow and API payloads are finalized. In the meantime, see [How it works](/docs/issuer/how-it-works) for the model and [Integrate via API](/docs/issuer/integrate) for the API shape.
+</Callout>
+
+This guide will walk an organization from zero to a first issued credential:
+
+1. Create your issuer account and get an API key.
+2. Define a credential: what it certifies and the work behind it.
+3. Issue it to a recipient, with the transaction sponsored end to end.
+4. Verify it independently, without calling Andamio.
+
+If you want to start now, the [Andamio API quickstart](/docs/guides/developers/api-quickstart) covers the lower-level developer path that Issuer is built on.

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -7,7 +7,7 @@
         "guides/developers",
         "sdk",
         "--- Issue Credentials ---",
-        "andamio-issuer",
+        "issuer",
         "--- Use the Platform ---",
         "guides",
         "--- Understand ---",

--- a/content/docs/protocol/index.mdx
+++ b/content/docs/protocol/index.mdx
@@ -4,7 +4,7 @@ description: A decentralized protocol for credential-gated collaboration with fu
 ---
 
 <Callout title="Advanced — protocol internals">
-This section documents Andamio's on-chain protocol (validators, transactions, tokens, state machine). Most builders don't need it — start with the [API](/docs/getting-started) and [Andamio Issuer](/docs/andamio-issuer). It's kept here as a reference for protocol integrators.
+This section documents Andamio's on-chain protocol (validators, transactions, tokens, state machine). Most builders don't need it — start with the [API](/docs/getting-started) and [Andamio Issuer](/docs/issuer). It's kept here as a reference for protocol integrators.
 </Callout>
 
 Andamio is a decentralized protocol for the creation and management of immutable, interoperable credentials. It provides a minimal global standard for placing credentials on the Cardano blockchain, and a flexible toolkit for defining and using new credentials.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,6 +15,8 @@ const config = {
   // subpage URLs to the index so existing links don't 404.
   async redirects() {
     return [
+      // Andamio Issuer is now its own product section; the old single page moved.
+      { source: '/docs/andamio-issuer', destination: '/docs/issuer', permanent: true },
       { source: '/docs/repositories/on-chain/:slug*', destination: '/docs/repositories', permanent: true },
       { source: '/docs/repositories/apis/:slug*', destination: '/docs/repositories', permanent: true },
       { source: '/docs/repositories/templates/:slug*', destination: '/docs/repositories', permanent: true },


### PR DESCRIPTION
First structural step toward the four jobs of the docs site. Grounded in the three papers under review in `ecosystem-enterprise#54` and the Product Circle product reference.

## What's here

**Front door (`/docs`)** — no longer drops visitors into API docs. It leads with a concise description of the suite and forks into three paths:
- **Andamio API** — the developer product
- **Andamio Issuer** — low-code, API-based credentialing
- **Explore the app** — end-user path, built on the API

Plus a "Two products, one protocol" section explaining the relationship, and credential differentiators distilled from the Light Paper.

**Andamio Issuer section (`content/docs/issuer/`)** — scaffolded, marked in-development:
- `index` — positioning, who it's for, why it beats a badge
- `how-it-works` — the credential model (six design decisions)
- `quickstart` — placeholder, "coming soon"
- `integrate` — the `/issuer/v1/` API shape (sponsored writes, scoped reads, `X-API-Key` tenant), marked preview
- Surfaced in the sidebar under **Issue Credentials**, parallel to the API.

**Housekeeping** — old `/docs/andamio-issuer` page removed and 308-redirected to `/docs/issuer`; inbound protocol link updated.

## Two things to flag

**1. Capability claims are deliberately conservative.** The draft papers state cross-issuer composability "runs on mainnet today," but the canonical anti-overclaim reference (`product-circle` / `product-reference.md`) lists it as **roadmap** (the `with_prereqs` validator path isn't wired into the deployed validator). I kept the Issuer copy off that claim until the paper review settles it. Worth resolving in #54.

**2. The product-tab toggle doesn't actually scope the sidebar — and this is pre-existing.** I tried making Issuer a coequal product *tab* (root toggle, like Protocol). It turns out the manual `sidebar.tabs` array only swaps the dropdown label; it doesn't filter the sidebar tree, because manual tab options carry no `urls` set and `RootToggle` is just a selector. The Protocol tab has the same limitation today. Making tabs truly scope needs a **Phase 2 restructure**: give each product its own tree root (move API content under an `api/` root, app guides under an `app/` root, keep `protocol/`), with `/docs` as the front door. That also repairs the Protocol toggle. I did **not** bundle that here — it's a deliberate, confirm-first change.

So for now Issuer is a prominent, navigable sidebar section rather than a toggle root. Reads cleanly; screenshots in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)