### PR TITLE
Add docs-governance skill + Phase 2 IA plan

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,6 +19,7 @@ Specialized tasks are organized into skills located in `.claude/skills/`. Each s
 | **glossary-game** | Collaborative terminology validation and refinement | `.claude/skills/glossary-game/` |
 | **scribe-walkthrough** | Convert Scribe markdown into polished MDX walkthrough pages | `.claude/skills/scribe-walkthrough/` |
 | **guide-pipeline** | Track guide writing progress, manage blockers, and publish pipeline | `.claude/skills/guide-pipeline/` |
+| **docs-governance** | Position complementary tools/support repos (CLI, SDK, templates, bots, dev repos) so they aid sales/contributions without competing with the products; holds the Phase 2 IA restructure plan | `.claude/skills/docs-governance/` |
 
 When working on tasks that match a skill's domain, read the skill's `SKILL.md` for specific instructions and supporting docs for context.
 

--- a/.claude/skills/docs-governance/SKILL.md
+++ b/.claude/skills/docs-governance/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: docs-governance
+description: Decide how to document complementary tools and support repos (CLI, SDK, templates, bots, dev/agent repos) so they drive adoption and contributions without competing with the products. Use when adding or reviewing docs for anything that is not itself a sold product, or when deciding where a tool belongs in the IA.
+---
+
+# Docs Governance
+
+The durable rules for how the Andamio docs site is shaped. This skill starts with one
+governed decision, **how to position complementary tools and support repos**, and will
+grow over time as we codify more IA and content rules. Treat it as living: when a rule
+proves wrong or incomplete, change it here and note why.
+
+## When to use
+
+- Adding docs for a tool, library, template, bot, or support repo that is **not** a product we sell.
+- Deciding where something belongs in the sidebar / IA.
+- Reviewing a PR that introduces or moves tool-related pages or links.
+- Onboarding a new complementary tool into the ecosystem.
+
+If you're documenting one of the **products** themselves (Andamio API, Andamio Issuer) or the
+**App** explore path or the **Protocol** reference, this skill governs only the *tool* pages that
+hang off them, not the product content itself.
+
+## Context: the spine the rules protect
+
+The site has [four jobs](./phase-2-ia-restructure.md):
+
+1. **Front door** (`/docs`): describe the suite, fork the visitor.
+2. **Andamio API**: the developer product (self-serve).
+3. **Andamio Issuer**: the low-code, API-based product (sales-led).
+4. **Explore the App**: end-user path; `app.andamio.io` is a reference implementation on the API.
+
+Two **products** are sold: API and Issuer. The App and Protocol are not sold; they support the
+products. Everything in this skill exists to keep that spine legible.
+
+## The principle
+
+> **Products are the spine; tools are accessories that hang off a product or a job.**
+
+A tool never becomes a top-level peer to the products. If a reader cannot tell at a glance what
+they **buy or build on** versus what merely **helps**, the docs have failed.
+
+## The gate: the two-line test
+
+Before any tool gets space in the docs, answer both. If you can't answer #1, it does not go in
+product docs: at most it gets a line in the Ecosystem index.
+
+1. **Which product or job does this make easier?** (API · Issuer · App · Protocol · cross-cutting)
+2. **What single action do we want the reader to take?** (Install · Use · Point your agent at it · Clone/fork · Add/try · Contribute)
+
+## Two reader intents, two confusions to prevent
+
+Every tool page serves up to two outcomes and should carry **both CTAs** when both apply:
+
+- **Adopt** (reduces friction → drives sales): "Use this to ship faster on [product]."
+- **Build / contribute** (drives contributions): "Source here, contribute here."
+
+Design against the two failure modes:
+
+- **Product confusion**: a tool reads like something you buy.
+  *Fix:* visual + structural separation, and the tool's first line names the product it serves.
+- **Sprawl confusion**: the same tool described in five places, drifting.
+  *Fix:* **one canonical page per tool**; every other mention is a contextual inline link to it.
+
+## The classification schema
+
+Fill these in for every tool. The living answers live in [`tool-registry.md`](./tool-registry.md).
+
+| Field | Options |
+|---|---|
+| **Serves** | API · Issuer · App · Protocol · cross-cutting |
+| **Type** | Accelerator (libs/templates) · Workflow tool (CLI) · Agent enablement · Integration/bot · Source repo |
+| **Audience** | Buyer-adopter · Builder · Contributor · End-user |
+| **Primary action** | Install · Use · Point your agent at it · Clone/fork · Add/try · Contribute |
+| **Canonical home** | exactly one page |
+| **Contextual surfaces** | the product guides where it's mentioned at the moment of need |
+| **Status** | Official-stable · Official-preview · Community |
+| **Outcome** | Adoption (sales) · Contribution · Retention |
+| **Owner** | who keeps the page current |
+
+## Placement rules (derived from Serves + Type)
+
+- **Serves one product** → canonical page lives **inside that product's section**, in a small
+  **Tools** group at the bottom of that product's sidebar. Surface it contextually in the guides
+  where it's needed.
+- **Cross-cutting** (serves more than one, or the ecosystem broadly) → canonical page in the single
+  shared **Ecosystem** zone, linked from the products it touches.
+- **Raw repos with no narrative** → one "Source & repositories" reference page. Never let bare
+  GitHub/SDK links compete with product nav in the main sidebar.
+- A tool may be **mentioned** anywhere it helps, but **documented** in exactly one place.
+- Tools never appear in the top-level product toggle.
+
+## Labeling conventions (prevent product/tool confusion)
+
+- Products carry no "tool" marker; they are the implicit spine.
+- Every tool page opens with a consistent header line: the tool name, a **Tool** tag, and its
+  **status** (`Official · Stable`, `Official · Preview`, or `Community`).
+- First sentence always states the served product: *"Use [tool] to [do X] with [product]."*
+- Status words are honest and load-bearing: do not label a community or experimental tool "Official · Stable."
+
+## The reusable tool-page template
+
+Every tool page uses the same shape so they read as a class, not as ad-hoc pages:
+
+```mdx
+---
+title: <Tool name>
+description: Use <tool> to <do X> with <product>.
+---
+
+> **<Tool name>** · Tool · <Official · Stable | Official · Preview | Community>
+
+One line: what it is and which product/job it serves.
+
+## When to reach for it
+<the situations where this is the right tool>
+
+## Start
+<the single primary action: install / point your agent / clone / add>
+
+## Source & contribute
+<repo link + contributing pointer, when applicable>
+
+## Where it fits
+<one line tying it back to the product flow, with a link>
+```
+
+## How this maps to the IA
+
+This schema folds into the [Phase 2 restructure](./phase-2-ia-restructure.md):
+
+- Each product root gets a small **Tools** group holding only the tools that serve it.
+- One shared **Ecosystem** entry holds cross-cutting/community tools and the repositories index.
+- The current "External" link dump and the standalone top-level "SDK" section are absorbed into
+  this, so tools stop visually competing with products.
+
+## Refining this skill
+
+This is a starting point, expected to evolve. When you change a rule:
+
+1. Edit the rule here and add a one-line rationale.
+2. Re-check [`tool-registry.md`](./tool-registry.md) for entries the change affects.
+3. If the change alters structure, reflect it in [`phase-2-ia-restructure.md`](./phase-2-ia-restructure.md).

--- a/.claude/skills/docs-governance/phase-2-ia-restructure.md
+++ b/.claude/skills/docs-governance/phase-2-ia-restructure.md
@@ -1,0 +1,103 @@
+# Phase 2: IA Restructure (plan)
+
+A confirm-first plan to make the [four jobs](./SKILL.md#context-the-spine-the-rules-protect)
+**structural**, so each product owns a scoped sidebar, and to place tools per the
+[governance rules](./SKILL.md). This is a one-time migration plan, not a durable rule; it lives
+here because it is the first major application of the governance.
+
+> **Status:** proposed, not started. Do not execute without sign-off. Phase 1 (front door +
+> Issuer scaffold) shipped in PR #30.
+
+## Goal
+
+- Each product is a real sidebar **root** that scopes the tree (when you're in Andamio API you see
+  only API; in Issuer only Issuer).
+- `/docs` is a neutral **front door**, no product preselected. (Per decision: API is *not* the default.)
+- Tools and support repos are placed by the governance schema, not scattered.
+
+## Why this is needed (the root-toggle finding)
+
+From PR #30: the manual `sidebar.tabs` array in `app/docs/layout.tsx` only swaps the dropdown
+**label**; it does not filter the sidebar tree, because manual tab options carry no `urls` set and
+`RootToggle` is just a selector. The **Protocol** tab has this same limitation today. Real scoping
+requires:
+
+1. Each product is a folder with `root: true` in its `meta.json` (so it appears in the page tree as a root).
+2. Tabs are **auto-derived** (`getSidebarTabs` walks the tree for `root` folders and computes each
+   tab's `urls` set), instead of a hand-written array.
+3. The layout renders the active root's subtree.
+
+## Target structure
+
+```
+/docs                         Front door (no product preselected)
+├─ api/         (root)        Andamio API: developer product
+│   ├─ quickstart, guides (auth, transactions, sponsorship, billing, …), reference/environments
+│   ├─ building-on-andamio    (the developer/protocol paper, conceptual intro)
+│   └─ Tools/                 CLI · Build with your agent (andamio-dev) · App Template · SDK
+├─ issuer/      (root)        Andamio Issuer: low-code product   (exists)
+│   ├─ overview, how-it-works, quickstart, integrate
+│   └─ Tools/                 (issuer-specific accelerators, as they appear)
+├─ app/         (root)        Explore the App: end-user path
+│   └─ roles, take a course, earn credentials, …   (today's guides/)
+├─ protocol/    (root)        Protocol: advanced reference   (exists)
+└─ ecosystem/   (root)        Ecosystem: Andamioscan · Repositories · Pioneers · community/cross-cutting tools
+```
+
+## Content moves (today → target)
+
+| Today | Target |
+|---|---|
+| `getting-started`, `guides/developers/*`, `sdk`, `guides/developers/api-quickstart`, `reference/environments` | `api/` |
+| `building-on-andamio` | `api/` (conceptual intro) |
+| `guides/` (roles, courses, projects, contributors) | `app/` |
+| `demo` | `app/` |
+| `repositories`, `pioneers`, Andamioscan | `ecosystem/` |
+| `light-paper`, `glossary` | **open decision** (front door / Ecosystem / top-level) |
+| `protocol/v2/whats-new`, `cost-estimation`, `security-audit` | API or Protocol (**open decision**) |
+| `reference` (page) | fold into `api/` reference or Ecosystem |
+
+Tools placement (per [registry](./tool-registry.md)): CLI, andamio-dev, App Template, SDK →
+**API → Tools**. Andamioscan, Repositories → **Ecosystem**. SDK stops being a top-level section.
+The "External" link group is absorbed (canonical pages where they exist, Ecosystem index otherwise).
+
+## Sequencing
+
+- **2a: Mechanism spike (do first, small):** convert one product (e.g. create `api/` root or use the
+  existing `issuer/` + `protocol/`) and prove the auto-derived toggle actually scopes the sidebar, and
+  that landing on `/docs` shows the front door with no product preselected. De-risks everything below.
+- **2b: Create product roots + move content** with redirects (see below).
+- **2c: Apply governance:** add per-product Tools groups + the Ecosystem zone; absorb External/SDK.
+- **2d: Front door + polish:** finalize the neutral landing and the open decisions.
+
+## Redirects (URL churn)
+
+Moving content under product roots changes many URLs. Every moved page needs a `permanent: true`
+redirect in `next.config.mjs`. High-traffic / linked ones to cover first:
+
+- `/docs/getting-started` → `/docs/api/getting-started`
+- `/docs/guides/developers/*` → `/docs/api/guides/*`
+- `/docs/guides/developers/api-quickstart` → `/docs/api/quickstart`
+- `/docs/sdk` → `/docs/api/tools/sdk`
+- `/docs/guides/*` (platform) → `/docs/app/*`
+- `/docs/repositories` → `/docs/ecosystem/repositories`
+- `/docs/reference/environments` → `/docs/api/reference/environments`
+
+(Generate the full list from a pre/post route diff during 2b.)
+
+## Risks & mitigations
+
+- **External links / SEO** → permanent redirects for every moved URL; diff routes before/after.
+- **Internal links** → grep-and-fix all in-repo links after moves; the build will not catch a stale
+  `/docs/...` link (content-collections silently 404s).
+- **Tooling that hardcodes paths** → `npm run docs-coverage` / `docs-drift` and the audit skills
+  reference `content/docs/...` paths; update them.
+- **Search index** → rebuilds from content; verify search after the move.
+
+## Open decisions (need James)
+
+1. **Default landing**: confirmed neutral front door (no product preselected). ✅ (already decided)
+2. **Explore the App**: full product root, or a lighter section under the front door? (Job 4 is "less important but present.")
+3. **Andamio Bot**: which job does it serve? Blocks its placement (see [registry](./tool-registry.md)).
+4. **The papers & glossary**: where do `light-paper`, `building-on-andamio`, and `glossary` live? (Light Paper reads like front-door/about; Building on Andamio is the API conceptual intro; Glossary is cross-cutting.)
+5. **Understand cluster**: `whats-new`, `cost-estimation`, `security-audit` → API, Protocol, or split?

--- a/.claude/skills/docs-governance/tool-registry.md
+++ b/.claude/skills/docs-governance/tool-registry.md
@@ -1,0 +1,53 @@
+# Tool Registry
+
+The living classification of every complementary tool and support repo, scored against the
+[classification schema](./SKILL.md#the-classification-schema). Add a row when a new tool appears;
+update a row when a tool's served product, status, or canonical home changes.
+
+Status legend: **Official · Stable** · **Official · Preview** · **Community** · **TBD** (needs a decision).
+
+## Placed tools
+
+| Tool | Serves | Type | Audience | Primary action | Canonical home | Surfaced in | Status |
+|---|---|---|---|---|---|---|---|
+| **Andamio CLI** (`andamio-cli`) | API / Protocol | Workflow tool | Builder | Install & use | API → Tools → CLI | API transactions guide, Protocol | Official · Stable |
+| **andamio-dev** | API | Agent enablement | Builder (via agent) | Point your agent at it | API → Tools → Build with your agent | API quickstart, CLI page | Official · Stable |
+| **App Template** (`andamio-app-template`) | API | Accelerator / example | Builder | Clone & deploy | API → Tools → Templates | "Create your own app" | Official · Stable |
+| **SDK** (`sdk.andamio.io`) | API | Accelerator (libs) | Builder | Install | API → Tools → SDK | API guides | Official · Stable |
+| **Andamioscan** | cross-cutting | Integration / explorer | Builder · End-user | Open / use | Ecosystem → Andamioscan | Protocol, App | Official · Stable |
+
+## Unplaced: needs a decision
+
+| Tool | Blocking question | Notes |
+|---|---|---|
+| **Andamio Bot** | **Which product or job does it serve?** | Until the served job is decided (test #1), it cannot be placed. If it serves a single product → that product's Tools group. If it's community/cross-cutting → Ecosystem. Confirm type (integration/bot) and status (Official vs Community). |
+
+## Notes per tool
+
+### Andamio CLI
+Wraps the full transaction lifecycle (build, sign, submit, register, confirm) and is the source of
+truth for what an Andamio transaction looks like. Calls the API (`preprod` / `mainnet`). Often driven
+by an agent via `andamio-dev`. Document the *use*; defer the canonical command reference to the repo.
+
+### andamio-dev
+The knowledge layer that teaches an agent the protocol, estimates costs, and drives the CLI. Its docs
+page is "Build with your agent" inside the API section: what it is, point your agent at it, what it
+unlocks. Not a product; an adoption accelerator.
+
+### App Template
+The fastest way to stand up an app on the API, using the same UX as `app.andamio.io` pointed at your
+own courses/projects. Document as the recommended starting point in "Create your own credentialing app."
+
+### SDK
+Currently a top-level sidebar section. Per the placement rules it should move under **API → Tools** so
+it stops reading as a peer to the products. Tracked in the Phase 2 plan.
+
+### Andamioscan
+On-chain explorer for Andamio state. Cross-cutting (useful from both Protocol and App contexts), so it
+lives in the shared Ecosystem zone.
+
+## Maintenance
+
+- Reviewed alongside any PR that adds or moves tool docs.
+- When a tool changes status (e.g., Preview → Stable, Community → Official), update the row and the
+  tool page's header line together.


### PR DESCRIPTION
A durable, refinable rule set for how the docs site is shaped, starting with the decision raised in the thread: how to position complementary tools and support repos so they aid sales and contributions without confusing people about what the products are.

## What's here (`.claude/skills/docs-governance/`)

**`SKILL.md`** — the governance rules:
- **Principle:** products are the spine; tools are accessories that hang off a product or a job, never top-level peers.
- **The two-line gate:** before any tool gets space, name (1) which product/job it serves and (2) the single action we want. Fail #1 → it doesn't go in product docs.
- **Dual CTA model:** adopt (drives sales) + build/contribute (drives contributions).
- **Classification schema, placement rules, labeling conventions, and a reusable tool-page template** so tool pages read as a class and never look like products.

**`tool-registry.md`** — living classification of each known tool (CLI, andamio-dev, App Template, SDK, Andamioscan) scored against the schema. **Andamio Bot is parked under "needs a decision"** until its served job is known, the schema literally can't place it without that.

**`phase-2-ia-restructure.md`** — the confirm-first plan that *applies* the governance:
- Make the four jobs structural via product **roots** that scope the sidebar (with the root-toggle finding from #30 written up).
- Content-move map, redirect list, risks, and sequencing (mechanism spike first).
- Tools placed per the registry (per-product Tools groups + a shared Ecosystem zone; SDK stops being a top-level section; the External dump is absorbed).
- **Open decisions for you** are listed at the bottom (incl. Andamio Bot's job, where the papers/glossary live, and whether Explore-the-App is a full root).

Registered in the repo `CLAUDE.md` skills table. Designed to be refined over time, the SKILL.md ends with how to evolve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)