### PR TITLE
Reorder sidebar top + rename API section

### DIFF
--- a/app/layout.config.tsx
+++ b/app/layout.config.tsx
@@ -30,10 +30,7 @@ export const baseOptions: BaseLayoutProps = {
     ),
     url: "https://andamio.io",
   },
-  links: [
-    {
-      text: "Guides",
-      url: "/docs/guides",
-    },
-  ],
+  // Guides lives in the docs sidebar tree (below Home), not as a nav link,
+  // so Home can sit at the very top of the sidebar.
+  links: [],
 };

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -1,8 +1,9 @@
 {
     "pages": [
         "index",
+        "[Guides](/docs/guides)",
+        "--- Andamio API ---",
         "guides/developers/api-quickstart",
-        "--- Use the API ---",
         "getting-started",
         "guides/developers",
         "sdk",


### PR DESCRIPTION
Top-of-sidebar tweaks from feedback:

1. **Home → top.** Moved the "Guides" nav link out of `layout.config.tsx` and into the sidebar tree, so Home is no longer pushed below it.
2. **Guides → directly below Home** (flat tree link to `/docs/guides`).
3. **API Quickstart → inside the product section** (was a floating top-level item).
4. **"Use the API" → "Andamio API"** to remove ambiguity (Andamio Issuer also has an API).

Verified in the dev server: sidebar now reads Home, Guides, then **Andamio API** (API Quickstart, Set Up Local Dev, Developer Guides, SDK), Issue Credentials, Use the Platform, …

Note: the "Guides" link is removed from the shared nav `links`, so it no longer appears in the home-page navbar (negligible; the home page leads with product cards). Say the word if you want it back there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)