### PR TITLE
docs: Contract Verification page (verify deployed contracts = published code)

### DIFF
--- a/content/docs/protocol/v2/contract-verification.mdx
+++ b/content/docs/protocol/v2/contract-verification.mdx
@@ -9,7 +9,7 @@ This page proves **which code is deployed** (identity). For **whether that code 
 
 ## How verification works
 
-Every Andamio on-chain contract is identified by a **script hash** — a `blake2b-224` hash of the *compiled* validator bytes (CIP-19). A script address embeds that hash as its payment credential; a minting policy ID **is** that hash. Because the hash binds to the compiled artifact rather than the source, anyone can confirm that a given address or policy is governed by exactly the code we publish the hash for — **without Andamio releasing the source**.
+Every Andamio on-chain contract is identified by a **script hash** — a `blake2b-224` hash of the *compiled* validator bytes. A script address embeds that hash as its payment credential (CIP-19); a minting policy ID **is** that hash. Because the hash binds to the compiled artifact rather than the source, anyone can confirm that a given address or policy is governed by exactly the code we publish the hash for — **without Andamio releasing the source**.
 
 The compiled bytes are already public: each validator is deployed on mainnet as a **reference script** (CIP-33), so the bytecode lives permanently in the UTxO set. To verify, you fetch those bytes, hash them, and confirm the result equals the published hash.
 
@@ -26,7 +26,7 @@ The policy ID **is** the script hash — verify it directly.
 | Instance Admin | `16c5b8eaf75a95d04cfdaa20d4a227835ec9c52db75ff0df12806a5f` |
 | Instance Provider | `da109ad01a8d7050e079ed7537930ba074b37fa3fdad76320788b2e8` |
 | Index Admin | `0de83d7df97fcf539c56a43605d77800d93917a678af5d2c1702c423` |
-| Index Ref | `98128687f1622463d2d37cba33150c14b32651ebc96cbb52ad975cba` |
+| Index Ref Token | `98128687f1622463d2d37cba33150c14b32651ebc96cbb52ad975cba` |
 
 ### Spend validators
 
@@ -35,7 +35,7 @@ The script hash is the address's payment credential.
 | Contract | Script address |
 |---|---|
 | Global State | `addr1x84ulqv75kc4880kx3e22jwec55n7arkazjljy34q5axxuvch6g0j0xe5272m2ysjs698fnmdlrpt4qseng6wp04z6psypmkwq` |
-| Index Ref | `addr1xyp6xrsf4z9tl7r2dkydg75763e2g5vjpawt9uksgjwetpuch6g0j0xe5272m2ysjs698fnmdlrpt4qseng6wp04z6ps4hvn9s` |
+| Index Ref Validator | `addr1xyp6xrsf4z9tl7r2dkydg75763e2g5vjpawt9uksgjwetpuch6g0j0xe5272m2ysjs698fnmdlrpt4qseng6wp04z6ps4hvn9s` |
 | Index Scripts | `addr1x8nkqvydps2qjml508k97fy4g42stl4hjpgrjql7jakyl55ch6g0j0xe5272m2ysjs698fnmdlrpt4qseng6wp04z6psfdeh90` |
 | Instance Governance Scripts | `addr1x9jptucmd72z6g2qw9c8dm4try6w8y34ac2a7ntudj0m8luch6g0j0xe5272m2ysjs698fnmdlrpt4qseng6wp04z6ps6tp63q` |
 | Instance Provider Scripts | `addr1x8dppxksr2xhq58q08kh2dunpws8fvml50766a3jq7yt96ych6g0j0xe5272m2ysjs698fnmdlrpt4qseng6wp04z6pse7ytve` |
@@ -46,8 +46,9 @@ The script hash is the address's payment credential.
 **A minting policy** — confirm the on-chain script hashes to the listed policy ID:
 
 ```bash
-# The /scripts/{hash} endpoint is keyed BY the hash, so a 200 with the script
-# is itself proof the compiled bytes hash to that value. Fetch the CBOR:
+# The /scripts/{hash} endpoint is keyed by the hash, so this only fetches the
+# bytes Blockfrost holds for that key — a 200 alone is not proof (any source
+# works). The proof is recomputing the hash yourself and matching it. Fetch:
 curl -s -H "project_id: $BLOCKFROST" \
   https://cardano-mainnet.blockfrost.io/api/v0/scripts/<script_hash>/cbor
 # To recompute locally: blake2b-224 over the language-tagged CBOR == <script_hash>

--- a/content/docs/protocol/v2/contract-verification.mdx
+++ b/content/docs/protocol/v2/contract-verification.mdx
@@ -1,0 +1,72 @@
+---
+title: Contract Verification
+description: Confirm that Andamio's deployed on-chain contracts are exactly the code we publish — cryptographically, without trusting Andamio and without any source release.
+---
+
+Enterprise integrators need to confirm that the contracts they rely on are governed by exactly the code Andamio claims — not take it on trust. You can verify this yourself, cryptographically, with no source release required.
+
+This page proves **which code is deployed** (identity). For **whether that code is correct** (behavior), see the independent [Security Audit](/docs/protocol/v2/security-audit).
+
+## How verification works
+
+Every Andamio on-chain contract is identified by a **script hash** — a `blake2b-224` hash of the *compiled* validator bytes (CIP-19). A script address embeds that hash as its payment credential; a minting policy ID **is** that hash. Because the hash binds to the compiled artifact rather than the source, anyone can confirm that a given address or policy is governed by exactly the code we publish the hash for — **without Andamio releasing the source**.
+
+The compiled bytes are already public: each validator is deployed on mainnet as a **reference script** (CIP-33), so the bytecode lives permanently in the UTxO set. To verify, you fetch those bytes, hash them, and confirm the result equals the published hash.
+
+## Andamio Protocol V2 — mainnet
+
+### Minting policies
+
+The policy ID **is** the script hash — verify it directly.
+
+| Contract | Script hash (= policy ID) |
+|---|---|
+| Access Token | `e760308d0c14096ff479ec5f2495455505feb790503903fe976c4fd2` |
+| Instance | `a8d2f21558831626a4ab01582a4568be1dac3298e6b92450a8e839a3` |
+| Instance Admin | `16c5b8eaf75a95d04cfdaa20d4a227835ec9c52db75ff0df12806a5f` |
+| Instance Provider | `da109ad01a8d7050e079ed7537930ba074b37fa3fdad76320788b2e8` |
+| Index Admin | `0de83d7df97fcf539c56a43605d77800d93917a678af5d2c1702c423` |
+| Index Ref | `98128687f1622463d2d37cba33150c14b32651ebc96cbb52ad975cba` |
+
+### Spend validators
+
+The script hash is the address's payment credential.
+
+| Contract | Script address |
+|---|---|
+| Global State | `addr1x84ulqv75kc4880kx3e22jwec55n7arkazjljy34q5axxuvch6g0j0xe5272m2ysjs698fnmdlrpt4qseng6wp04z6psypmkwq` |
+| Index Ref | `addr1xyp6xrsf4z9tl7r2dkydg75763e2g5vjpawt9uksgjwetpuch6g0j0xe5272m2ysjs698fnmdlrpt4qseng6wp04z6ps4hvn9s` |
+| Index Scripts | `addr1x8nkqvydps2qjml508k97fy4g42stl4hjpgrjql7jakyl55ch6g0j0xe5272m2ysjs698fnmdlrpt4qseng6wp04z6psfdeh90` |
+| Instance Governance Scripts | `addr1x9jptucmd72z6g2qw9c8dm4try6w8y34ac2a7ntudj0m8luch6g0j0xe5272m2ysjs698fnmdlrpt4qseng6wp04z6ps6tp63q` |
+| Instance Provider Scripts | `addr1x8dppxksr2xhq58q08kh2dunpws8fvml50766a3jq7yt96ych6g0j0xe5272m2ysjs698fnmdlrpt4qseng6wp04z6pse7ytve` |
+| Instance Scripts | `addr1xx5d9us4tzp3vf4y4vq4s2j9dzlpmtpjnrntjfzs4r5rnguch6g0j0xe5272m2ysjs698fnmdlrpt4qseng6wp04z6psl3she9` |
+
+## Verify it yourself
+
+**A minting policy** — confirm the on-chain script hashes to the listed policy ID:
+
+```bash
+# The /scripts/{hash} endpoint is keyed BY the hash, so a 200 with the script
+# is itself proof the compiled bytes hash to that value. Fetch the CBOR:
+curl -s -H "project_id: $BLOCKFROST" \
+  https://cardano-mainnet.blockfrost.io/api/v0/scripts/<script_hash>/cbor
+# To recompute locally: blake2b-224 over the language-tagged CBOR == <script_hash>
+```
+
+**A spend validator** — extract the script hash from the address, then verify as above:
+
+```bash
+# Decode the address to its payment credential (the script hash):
+cardano-cli address info --address <addr1x...>
+# → "paymentCredential": { "scriptHash": "..." }
+# Then fetch + verify that script hash exactly as for a minting policy.
+```
+
+A match proves the address or policy is governed by exactly the compiled validator we publish the hash for. No source, no trust in Andamio.
+
+## Identity and correctness, together
+
+- **Identity** (this page): the cryptographic proof above confirms *which* code is deployed.
+- **Correctness** ([Security Audit](/docs/protocol/v2/security-audit)): TxPipe independently audited the validator and minting-policy surface, covering threats like token theft, protocol halting, and double satisfaction.
+
+Together they let an integrator confirm both that Andamio runs the code it claims, and that the code was independently reviewed.

--- a/content/docs/protocol/v2/contract-verification.mdx
+++ b/content/docs/protocol/v2/contract-verification.mdx
@@ -49,9 +49,14 @@ The script hash is the address's payment credential.
 # The /scripts/{hash} endpoint is keyed by the hash, so this only fetches the
 # bytes Blockfrost holds for that key — a 200 alone is not proof (any source
 # works). The proof is recomputing the hash yourself and matching it. Fetch:
-curl -s -H "project_id: $BLOCKFROST" \
-  https://cardano-mainnet.blockfrost.io/api/v0/scripts/<script_hash>/cbor
-# To recompute locally: blake2b-224 over the language-tagged CBOR == <script_hash>
+CBOR=$(curl -s -H "project_id: $BLOCKFROST" \
+  https://cardano-mainnet.blockfrost.io/api/v0/scripts/<script_hash>/cbor | jq -r .cbor)
+# Andamio's validators are Plutus V3 (language-tag byte 0x03). Let cardano-cli
+# prepend the tag and hash — it computes blake2b-224(0x03 || script):
+printf '{"type":"PlutusScriptV3","description":"","cborHex":"%s"}' "$CBOR" > script.plutus
+cardano-cli hash script --script-file script.plutus   # must equal <script_hash>
+# If it does not match, the bytes are double-CBOR-wrapped: decode one CBOR
+# bytestring layer (e.g. `cbor2`/`xxd`) before re-wrapping, then hash again.
 ```
 
 **A spend validator** — extract the script hash from the address, then verify as above:

--- a/content/docs/protocol/v2/meta.json
+++ b/content/docs/protocol/v2/meta.json
@@ -2,6 +2,8 @@
     "title": "Protocol V2",
     "pages": [
         "index",
+        "contract-verification",
+        "security-audit",
         "state-machine",
         "validators",
         "transactions",


### PR DESCRIPTION
## What

A net-new **Contract Verification** page under Protocol V2, answering the enterprise-integrator question: *"How do I confirm the deployed contract is the code Andamio claims?"*

A Cardano script hash is the `blake2b-224` of the **compiled** validator bytes (CIP-19); the policy ID *is* that hash, and a script address embeds it. Andamio's validators deploy as **reference scripts** (CIP-33), so the bytes are already public on-chain. An integrator fetches them, hashes them, and compares — cryptographic proof, no source release, no trust in us.

Includes the **real mainnet v2 manifest** (6 minting-policy hashes + 6 spend-script addresses, from `public/yaml/deployments/mainnet-v2/params.yaml`) and copy-paste Blockfrost / `cardano-cli` verify commands. Cross-links the existing **Security Audit** page so the two halves sit together: this page = *which* code is deployed (identity); the audit = *whether it's correct* (behavior). Also surfaces `security-audit` in the nav (it was reachable but unlisted).

## Review needed before merge

This is **for review** — please confirm the data and these open items:
- [ ] **Reference-script UTxO refs** — listing each validator's `tx_hash#index` would let a verifier fetch the exact bytes in one hop. Add if available.
- [ ] **Does the TxPipe audit report cite these exact script hashes?** If so, we can state the audit covers the deployed artifacts, not just the source.
- [ ] **Version field** — `mainnet-v2/params.yaml` carries `version: v1`; confirm canonical and whether global-state is intentionally shared v1↔v2.
- [ ] **Completeness** — `params.yaml` leaves some policy IDs blank (`init_index_policyid`, treasuries); confirm the manifest should list only deployed contracts.

A CIP-57 `plutus.json` blueprint is a natural machine-readable companion (phase 2), as is an interactive verifier widget.