### PR TITLE
docs: fix spend-validator hash extraction (verified on mainnet)

### DIFF
--- a/content/docs/protocol/v2/contract-verification.mdx
+++ b/content/docs/protocol/v2/contract-verification.mdx
@@ -62,10 +62,10 @@ cardano-cli hash script --script-file script.plutus   # must equal <script_hash>
 **A spend validator** — extract the script hash from the address, then verify as above:
 
 ```bash
-# Decode the address to its payment credential (the script hash):
-cardano-cli address info --address <addr1x...>
-# → "paymentCredential": { "scriptHash": "..." }
-# Then fetch + verify that script hash exactly as for a minting policy.
+# The script hash is the payment credential embedded in the address: the
+# 28 bytes right after the 1-byte header. Decode to base16 and slice it out:
+cardano-cli address info --address <addr1x...> | jq -r .base16 | cut -c3-58
+# → the script hash. Then fetch + verify it exactly as for a minting policy.
 ```
 
 A match proves the address or policy is governed by exactly the compiled validator we publish the hash for. No source, no trust in Andamio.


### PR DESCRIPTION
## What

The Contract Verification page (merged in #34) told readers to extract a spend validator's script hash with:

```bash
cardano-cli address info --address <addr1x...>
# → "paymentCredential": { "scriptHash": "..." }
```

But `cardano-cli address info` emits no `paymentCredential` object — only `address`, `base16`, `encoding`, `era`, `type`. A reader following it literally gets `null`.

## Fix

Extract the script hash from `base16` — drop the 1-byte header, take the 28-byte payment credential:

```bash
cardano-cli address info --address <addr1x...> | jq -r .base16 | cut -c3-58
```

## Verification

Found and verified by spot-checking the live page end-to-end on mainnet:

- **Minting path** (Access Token `e760308d…`): on-chain CBOR → PlutusScriptV3 envelope → `cardano-cli hash script` reproduces the published hash exactly. Correct as written.
- **Spend path** (Global State): `base16` slice yields `ebcf819e…`, which matches `cardano-cli hash script` over the fetched reference script. Confirms the address embeds the script it claims.

## Still open (not in this PR)

Manifest-drift guard (the 12 values duplicate `params.yaml` with no sync check) remains the main residual advisory from the #34 review.