### PR TITLE
feat: Docs Phase 2 IA — front door + six-root governance (Phase A)

### DIFF
--- a/.claude/skills/docs-governance/SKILL.md
+++ b/.claude/skills/docs-governance/SKILL.md
@@ -17,35 +17,45 @@ proves wrong or incomplete, change it here and note why.
 - Reviewing a PR that introduces or moves tool-related pages or links.
 - Onboarding a new complementary tool into the ecosystem.
 
-If you're documenting one of the **products** themselves (Andamio API, Andamio Issuer) or the
-**App** explore path or the **Protocol** reference, this skill governs only the *tool* pages that
-hang off them, not the product content itself.
+If you're documenting one of the **products** themselves (Andamio API, Andamio Issuer, Credential
+Badges), the **Apps & Tooling** or **Developer Community** zones, or the **Protocol** reference,
+this skill governs only the *tool* pages that hang off them, not the product content itself.
 
 ## Context: the spine the rules protect
 
-The site has [four jobs](./phase-2-ia-restructure.md):
+The docs sidebar roots mirror the [#28 Roadmap initiatives](./phase-2-ia-restructure.md), so the
+docs and the roadmap stay legible together. **Six roots:**
 
-1. **Front door** (`/docs`): describe the suite, fork the visitor.
-2. **Andamio API**: the developer product (self-serve).
-3. **Andamio Issuer**: the low-code, API-based product (sales-led).
-4. **Explore the App**: end-user path; `app.andamio.io` is a reference implementation on the API.
+1. **Andamio API**: the developer product (self-serve).
+2. **Andamio Issuer**: the low-code, API-based product (sales-led).
+3. **Credential Badges**: the flagship credential product.
+4. **Apps & Tooling**: the category zone — Explore the App, Andamio Bot, CLI, App Template, SDK, Andamioscan.
+5. **Developer Community**: Pioneers, Repositories, and community tools.
+6. **Protocol**: on-chain internals (advanced reference).
 
-Two **products** are sold: API and Issuer. The App and Protocol are not sold; they support the
-products. Everything in this skill exists to keep that spine legible.
+`/docs` is a neutral **front door** (no product preselected). Glossary and Light Paper are
+cross-cutting references on the front door, **not** roots.
+
+Three **products** anchor the spine (API, Issuer, Credential Badges). Apps & Tooling, Developer
+Community, and Protocol are supporting zones. Everything in this skill exists to keep that spine
+legible.
 
 ## The principle
 
-> **Products are the spine; tools are accessories that hang off a product or a job.**
+> **Products and product-zones are the spine; tools are accessories that hang off a product or a zone.**
 
-A tool never becomes a top-level peer to the products. If a reader cannot tell at a glance what
-they **buy or build on** versus what merely **helps**, the docs have failed.
+No single **tool** becomes a top-level root peer to the products. A tool hangs off the product it
+serves (in that product's Tools group) or, when it is itself one of the apps, lives inside the
+**Apps & Tooling** zone — the Andamio Bot is an app there, not a sold-product peer. If a reader
+cannot tell at a glance what they **buy or build on** versus what merely **helps**, the docs have
+failed.
 
 ## The gate: the two-line test
 
 Before any tool gets space in the docs, answer both. If you can't answer #1, it does not go in
-product docs: at most it gets a line in the Ecosystem index.
+product docs: at most it gets a line in the Developer Community index.
 
-1. **Which product or job does this make easier?** (API · Issuer · App · Protocol · cross-cutting)
+1. **Which product or zone does this make easier?** (API · Issuer · Credential Badges · Apps & Tooling · Developer Community · Protocol · cross-cutting)
 2. **What single action do we want the reader to take?** (Install · Use · Point your agent at it · Clone/fork · Add/try · Contribute)
 
 ## Two reader intents, two confusions to prevent
@@ -68,7 +78,7 @@ Fill these in for every tool. The living answers live in [`tool-registry.md`](./
 
 | Field | Options |
 |---|---|
-| **Serves** | API · Issuer · App · Protocol · cross-cutting |
+| **Serves** | API · Issuer · Credential Badges · Apps & Tooling · Developer Community · Protocol · cross-cutting |
 | **Type** | Accelerator (libs/templates) · Workflow tool (CLI) · Agent enablement · Integration/bot · Source repo |
 | **Audience** | Buyer-adopter · Builder · Contributor · End-user |
 | **Primary action** | Install · Use · Point your agent at it · Clone/fork · Add/try · Contribute |
@@ -83,12 +93,12 @@ Fill these in for every tool. The living answers live in [`tool-registry.md`](./
 - **Serves one product** → canonical page lives **inside that product's section**, in a small
   **Tools** group at the bottom of that product's sidebar. Surface it contextually in the guides
   where it's needed.
-- **Cross-cutting** (serves more than one, or the ecosystem broadly) → canonical page in the single
-  shared **Ecosystem** zone, linked from the products it touches.
-- **Raw repos with no narrative** → one "Source & repositories" reference page. Never let bare
-  GitHub/SDK links compete with product nav in the main sidebar.
+- **Is one of the apps, or cross-cutting tooling** (Bot, CLI, App Template, SDK, Andamioscan) →
+  canonical page in the **Apps & Tooling** zone, linked from the products it touches.
+- **Community-facing or a raw repo with no narrative** → the **Developer Community** zone (Pioneers,
+  Repositories index). Never let bare GitHub/SDK links compete with product nav in the main sidebar.
 - A tool may be **mentioned** anywhere it helps, but **documented** in exactly one place.
-- Tools never appear in the top-level product toggle.
+- Tools never appear as a top-level root in the product toggle.
 
 ## Labeling conventions (prevent product/tool confusion)
 
@@ -130,9 +140,10 @@ One line: what it is and which product/job it serves.
 This schema folds into the [Phase 2 restructure](./phase-2-ia-restructure.md):
 
 - Each product root gets a small **Tools** group holding only the tools that serve it.
-- One shared **Ecosystem** entry holds cross-cutting/community tools and the repositories index.
+- The **Apps & Tooling** root holds the apps and cross-cutting tooling (Bot, CLI, App Template, SDK,
+  Andamioscan); the **Developer Community** root holds the repositories index and community tools.
 - The current "External" link dump and the standalone top-level "SDK" section are absorbed into
-  this, so tools stop visually competing with products.
+  this (SDK now lives under Apps & Tooling), so tools stop visually competing with products.
 
 ## Refining this skill
 

--- a/.claude/skills/docs-governance/phase-2-ia-restructure.md
+++ b/.claude/skills/docs-governance/phase-2-ia-restructure.md
@@ -1,89 +1,108 @@
 # Phase 2: IA Restructure (plan)
 
-A confirm-first plan to make the [four jobs](./SKILL.md#context-the-spine-the-rules-protect)
-**structural**, so each product owns a scoped sidebar, and to place tools per the
+A confirm-first plan to make the [six roots](./SKILL.md#context-the-spine-the-rules-protect)
+**structural**, so each product/zone owns a scoped sidebar, and to place tools per the
 [governance rules](./SKILL.md). This is a one-time migration plan, not a durable rule; it lives
 here because it is the first major application of the governance.
 
-> **Status:** proposed, not started. Do not execute without sign-off. Phase 1 (front door +
-> Issuer scaffold) shipped in PR #30.
+> **Status:** roadmap-aligned six-root spine signed off (orch Phase-2 IA session, 2026-06-29).
+> Execution tracked in `andamio-docs` (`docs/plans/2026-06-29-001-feat-docs-phase2-six-root-ia-plan.md`).
+> Phase 1 (front door + Issuer scaffold) shipped in PR #30.
 
 ## Goal
 
-- Each product is a real sidebar **root** that scopes the tree (when you're in Andamio API you see
-  only API; in Issuer only Issuer).
+- Each product/zone is a real sidebar **root** that scopes the tree (when you're in Andamio API you
+  see only API; in Apps & Tooling only Apps & Tooling).
 - `/docs` is a neutral **front door**, no product preselected. (Per decision: API is *not* the default.)
 - Tools and support repos are placed by the governance schema, not scattered.
 
-## Why this is needed (the root-toggle finding)
+## The roots (mirror the #28 Roadmap initiatives)
 
-From PR #30: the manual `sidebar.tabs` array in `app/docs/layout.tsx` only swaps the dropdown
-**label**; it does not filter the sidebar tree, because manual tab options carry no `urls` set and
-`RootToggle` is just a selector. The **Protocol** tab has this same limitation today. Real scoping
-requires:
-
-1. Each product is a folder with `root: true` in its `meta.json` (so it appears in the page tree as a root).
-2. Tabs are **auto-derived** (`getSidebarTabs` walks the tree for `root` folders and computes each
-   tab's `urls` set), instead of a hand-written array.
-3. The layout renders the active root's subtree.
-
-## Target structure
+The docs roots use exactly the #28 Roadmap initiative names so the docs and roadmap stay legible
+together:
 
 ```
-/docs                         Front door (no product preselected)
-├─ api/         (root)        Andamio API: developer product
-│   ├─ quickstart, guides (auth, transactions, sponsorship, billing, …), reference/environments
-│   ├─ building-on-andamio    (the developer/protocol paper, conceptual intro)
-│   └─ Tools/                 CLI · Build with your agent (andamio-dev) · App Template · SDK
-├─ issuer/      (root)        Andamio Issuer: low-code product   (exists)
-│   ├─ overview, how-it-works, quickstart, integrate
-│   └─ Tools/                 (issuer-specific accelerators, as they appear)
-├─ app/         (root)        Explore the App: end-user path
-│   └─ roles, take a course, earn credentials, …   (today's guides/)
-├─ protocol/    (root)        Protocol: advanced reference   (exists)
-└─ ecosystem/   (root)        Ecosystem: Andamioscan · Repositories · Pioneers · community/cross-cutting tools
+/docs                          Front door (neutral — no product preselected)
+├─ api/               (root)   Andamio API — developer product
+├─ issuer/            (root)   Andamio Issuer — low-code product
+├─ credential-badges/ (root)   Credential Badges — flagship (already top-level; keep)
+├─ apps-tooling/      (root)   Apps & Tooling — Explore the App · Andamio Bot · CLI · App Template · SDK · Andamioscan
+├─ developer-community/ (root) Developer Community — Pioneers · Repositories · community tools
+└─ protocol/          (root)   Protocol — internals  ⚠️ contents NOT triaged here (see out of scope)
+   cross-cutting (NOT a root): Glossary · Light Paper → front door / Reference zone
 ```
 
-## Content moves (today → target)
+**Resolved placement decisions** (do not re-open):
+
+- **Andamio Bot → Apps & Tooling** (it's one of the apps on the roadmap, not an "add to your server" tool).
+- **Explore the App → Apps & Tooling** (folds in; *not* its own co-equal root).
+- **Developer Community is its own root** (Pioneers + Repositories + community tools).
+- **Glossary + Light Paper → cross-cutting Reference zone** on the front door, not roots. (Papers stay
+  woven per the locked papers decision: the landing page is the artifact home; docs gets only woven content.)
+
+## How scoping actually works (the mechanism, verified)
+
+Verified against `fumadocs-ui` / `fumadocs-core` **15.4.1**:
+
+- The sidebar tree is scoped **automatically** by Fumadocs' `TreeContext` (`contexts/tree.js`): it
+  runs `searchPath(tree, pathname)` then `findLast(folder.root === true)` and renders only that
+  folder's children. **A folder with `root: true` already gets a scoped subtree today** — `protocol/`
+  does. The tree filtering is *not* the tabs' job.
+- `RootToggle` and a tab's `urls` set only drive the **dropdown selector and active-highlight** —
+  they do not filter the tree.
+- The fix is therefore to switch `app/docs/layout.tsx` from a hand-written `sidebar.tabs` array to
+  **`sidebar={{ tabs: true }}`** (auto-derive). `DocsLayout` calls `getSidebarTabs(tree)` internally,
+  walking the tree for `root: true` folders and computing each tab's `urls` set. This makes the
+  dropdown list all roots and highlight the active one robustly.
+
+> Note: this corrects the earlier "manual tabs carry no `urls` set, so the tree isn't filtered"
+> framing. The tree filtering was never the tabs' job — it comes from `TreeContext`. Don't hunt for
+> a `urls`-based tree filter; it does not exist.
+
+## Content moves (today → target root)
+
+`(soft)` = reasonable call, revisit if it reads wrong in situ.
 
 | Today | Target |
 |---|---|
-| `getting-started`, `guides/developers/*`, `sdk`, `guides/developers/api-quickstart`, `reference/environments` | `api/` |
-| `building-on-andamio` | `api/` (conceptual intro) |
-| `guides/` (roles, courses, projects, contributors) | `app/` |
-| `demo` | `app/` |
-| `repositories`, `pioneers`, Andamioscan | `ecosystem/` |
-| `light-paper`, `glossary` | **open decision** (front door / Ecosystem / top-level) |
-| `protocol/v2/whats-new`, `cost-estimation`, `security-audit` | API or Protocol (**open decision**) |
-| `reference` (page) | fold into `api/` reference or Ecosystem |
+| `getting-started`, `guides/developers/*` (excl. `cli/`), `guides/developers/api-quickstart`, `reference/` | `api/` |
+| `building-on-andamio` | `api/` — conceptual intro (soft) |
+| `guides/courses`, `guides/projects`, `guides/contributors`, `demo` | `apps-tooling/` (Explore the App path) |
+| `guides/developers/cli/`, `sdk/` | `apps-tooling/` (tools) |
+| Andamioscan · App Template · Andamio Bot (pages where they exist) | `apps-tooling/` |
+| `repositories`, `pioneers` | `developer-community/` |
+| `issuer`, `credential-badges` | stay — add `root: true` |
+| `protocol` | stay — already `root: true`, **contents untouched** |
+| `light-paper`, `glossary` | stay top-level; surfaced in front-door Reference zone (no move) |
 
-Tools placement (per [registry](./tool-registry.md)): CLI, andamio-dev, App Template, SDK →
-**API → Tools**. Andamioscan, Repositories → **Ecosystem**. SDK stops being a top-level section.
-The "External" link group is absorbed (canonical pages where they exist, Ecosystem index otherwise).
+Tools placement (per [registry](./tool-registry.md)): CLI, App Template, SDK, Andamioscan, Andamio Bot
+→ **Apps & Tooling**. Pioneers, Repositories → **Developer Community**. SDK stops being a top-level
+section. The "External" link group is absorbed (canonical pages where they exist, zone index otherwise).
 
 ## Sequencing
 
-- **2a: Mechanism spike (do first, small):** convert one product (e.g. create `api/` root or use the
-  existing `issuer/` + `protocol/`) and prove the auto-derived toggle actually scopes the sidebar, and
-  that landing on `/docs` shows the front door with no product preselected. De-risks everything below.
-- **2b: Create product roots + move content** with redirects (see below).
-- **2c: Apply governance:** add per-product Tools groups + the Ecosystem zone; absorb External/SDK.
-- **2d: Front door + polish:** finalize the neutral landing and the open decisions.
+- **2a: Mechanism spike (do first, small):** switch to auto-derived tabs and stand up a minimal `api/`
+  root **alongside** the existing `protocol/` root; prove both scope and that `/docs` shows the neutral
+  front door. De-risks everything below. **Hard gate — if it does not scope, stop and report.**
+- **2b: Create the six roots + move content** with redirects (see below).
+- **2c: Apply governance:** add per-product Tools groups + the Apps & Tooling / Developer Community
+  zones; absorb External/SDK.
+- **2d: Front door + polish:** finalize the neutral landing and the Reference zone (Glossary, Light Paper).
 
 ## Redirects (URL churn)
 
-Moving content under product roots changes many URLs. Every moved page needs a `permanent: true`
-redirect in `next.config.mjs`. High-traffic / linked ones to cover first:
+Moving content under roots changes many URLs. Every moved page needs a `permanent: true` redirect in
+`next.config.mjs` — generate the full list from a pre/post route diff during 2b. Examples:
 
 - `/docs/getting-started` → `/docs/api/getting-started`
 - `/docs/guides/developers/*` → `/docs/api/guides/*`
-- `/docs/guides/developers/api-quickstart` → `/docs/api/quickstart`
-- `/docs/sdk` → `/docs/api/tools/sdk`
-- `/docs/guides/*` (platform) → `/docs/app/*`
-- `/docs/repositories` → `/docs/ecosystem/repositories`
-- `/docs/reference/environments` → `/docs/api/reference/environments`
+- `/docs/sdk` → `/docs/apps-tooling/sdk`
+- `/docs/guides/*` (platform) → `/docs/apps-tooling/*`
+- `/docs/repositories` → `/docs/developer-community/repositories`
+- `/docs/pioneers/*` → `/docs/developer-community/pioneers/*`
 
-(Generate the full list from a pre/post route diff during 2b.)
+(The existing `/docs/repositories/*` redirects already in `next.config.mjs` now need to chain to the
+new `developer-community/` location — reconcile, don't duplicate.)
 
 ## Risks & mitigations
 
@@ -91,13 +110,15 @@ redirect in `next.config.mjs`. High-traffic / linked ones to cover first:
 - **Internal links** → grep-and-fix all in-repo links after moves; the build will not catch a stale
   `/docs/...` link (content-collections silently 404s).
 - **Tooling that hardcodes paths** → `npm run docs-coverage` / `docs-drift` and the audit skills
-  reference `content/docs/...` paths; update them.
+  reference `content/docs/...` paths; update them. CLAUDE.md's Pioneers archival paths move too.
 - **Search index** → rebuilds from content; verify search after the move.
 
-## Open decisions (need James)
+## Out of scope (separate workstreams — do NOT do here)
 
-1. **Default landing**: confirmed neutral front door (no product preselected). ✅ (already decided)
-2. **Explore the App**: full product root, or a lighter section under the front door? (Job 4 is "less important but present.")
-3. **Andamio Bot**: which job does it serve? Blocks its placement (see [registry](./tool-registry.md)).
-4. **The papers & glossary**: where do `light-paper`, `building-on-andamio`, and `glossary` live? (Light Paper reads like front-door/about; Building on Andamio is the API conceptual intro; Glossary is cross-cutting.)
-5. **Understand cluster**: `whats-new`, `cost-estimation`, `security-audit` → API, Protocol, or split?
+- **Protocol deep triage** — the contents of `protocol/v2/*` (state-machine, transactions, validators,
+  tokens) and the **Understand cluster** placement (`whats-new`, `cost-estimation`, `security-audit`).
+  This restructure stands up the `protocol/` root but does **not** triage its contents.
+  (`security-audit` / contract-verification is integrator-facing → likely also surfaces under API, but
+  that's decided in the triage, not here.)
+- **De-genericize the 45 token/validator stubs** — mostly under `protocol/v2/`, overlaps with the
+  triage above.

--- a/.claude/skills/docs-governance/tool-registry.md
+++ b/.claude/skills/docs-governance/tool-registry.md
@@ -10,24 +10,29 @@ Status legend: **Official · Stable** · **Official · Preview** · **Community*
 
 | Tool | Serves | Type | Audience | Primary action | Canonical home | Surfaced in | Status |
 |---|---|---|---|---|---|---|---|
-| **Andamio CLI** (`andamio-cli`) | API / Protocol | Workflow tool | Builder | Install & use | API → Tools → CLI | API transactions guide, Protocol | Official · Stable |
+| **Andamio CLI** (`andamio-cli`) | Apps & Tooling | Workflow tool | Builder | Install & use | Apps & Tooling → CLI | API transactions guide, Protocol | Official · Stable |
 | **andamio-dev** | API | Agent enablement | Builder (via agent) | Point your agent at it | API → Tools → Build with your agent | API quickstart, CLI page | Official · Stable |
-| **App Template** (`andamio-app-template`) | API | Accelerator / example | Builder | Clone & deploy | API → Tools → Templates | "Create your own app" | Official · Stable |
-| **SDK** (`sdk.andamio.io`) | API | Accelerator (libs) | Builder | Install | API → Tools → SDK | API guides | Official · Stable |
-| **Andamioscan** | cross-cutting | Integration / explorer | Builder · End-user | Open / use | Ecosystem → Andamioscan | Protocol, App | Official · Stable |
+| **App Template** (`andamio-app-template`) | Apps & Tooling | Accelerator / example | Builder | Clone & deploy | Apps & Tooling → Templates | "Create your own app" | Official · Stable |
+| **SDK** (`sdk.andamio.io`) | Apps & Tooling | Accelerator (libs) | Builder | Install | Apps & Tooling → SDK | API guides | Official · Stable |
+| **Andamioscan** | Apps & Tooling | Integration / explorer | Builder · End-user | Open / use | Apps & Tooling → Andamioscan | Protocol, Apps & Tooling | Official · Stable |
+| **Andamio Bot** | Apps & Tooling | Integration / bot | Builder · End-user | Add / try | Apps & Tooling → Bot | Apps & Tooling | TBD (confirm Official vs Community) |
+| **Repositories index** | Developer Community | Source repo | Builder · Contributor | Clone / contribute | Developer Community → Repositories | Protocol, Apps & Tooling | Official · Stable |
 
-## Unplaced: needs a decision
+Andamio Bot is one of the **apps** on the #28 Roadmap, so it lives inside the Apps & Tooling zone —
+not a sold-product peer (see [SKILL.md principle](./SKILL.md#the-principle)). Confirm its status
+(Official vs Community) before publishing its page.
 
-| Tool | Blocking question | Notes |
-|---|---|---|
-| **Andamio Bot** | **Which product or job does it serve?** | Until the served job is decided (test #1), it cannot be placed. If it serves a single product → that product's Tools group. If it's community/cross-cutting → Ecosystem. Confirm type (integration/bot) and status (Official vs Community). |
+**Developer Community zone** also holds **Pioneers** (the cohort program) alongside the Repositories
+index. Pioneers is a program, not a tool, so it has no registry row — but its docs live under the
+`developer-community/` root.
 
 ## Notes per tool
 
 ### Andamio CLI
 Wraps the full transaction lifecycle (build, sign, submit, register, confirm) and is the source of
 truth for what an Andamio transaction looks like. Calls the API (`preprod` / `mainnet`). Often driven
-by an agent via `andamio-dev`. Document the *use*; defer the canonical command reference to the repo.
+by an agent via `andamio-dev`. Lives in the Apps & Tooling zone; surfaced contextually in the API
+transactions guide and Protocol. Document the *use*; defer the canonical command reference to the repo.
 
 ### andamio-dev
 The knowledge layer that teaches an agent the protocol, estimates costs, and drives the CLI. Its docs
@@ -39,12 +44,17 @@ The fastest way to stand up an app on the API, using the same UX as `app.andamio
 own courses/projects. Document as the recommended starting point in "Create your own credentialing app."
 
 ### SDK
-Currently a top-level sidebar section. Per the placement rules it should move under **API → Tools** so
-it stops reading as a peer to the products. Tracked in the Phase 2 plan.
+Currently a top-level sidebar section. Per the placement rules it moves under **Apps & Tooling → SDK**
+so it stops reading as a peer to the products. Tracked in the Phase 2 plan.
 
 ### Andamioscan
-On-chain explorer for Andamio state. Cross-cutting (useful from both Protocol and App contexts), so it
-lives in the shared Ecosystem zone.
+On-chain explorer for Andamio state. Useful from both Protocol and app contexts; lives in the
+**Apps & Tooling** zone, surfaced contextually where it helps.
+
+### Andamio Bot
+An app on the #28 Roadmap (App v2.5.0 · Bot v1.0). Lives inside the **Apps & Tooling** zone as one of
+the apps, not a sold-product peer. Confirm its status (Official vs Community) and primary action before
+publishing the page.
 
 ## Maintenance
 

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -33,7 +33,25 @@ const ENTRIES = [
     href: "/docs/issuer",
     cta: "Explore Issuer",
   },
+  {
+    n: "05",
+    title: "Credential Badges",
+    body: "Issue verifiable, on-chain credential badges that learners carry anywhere.",
+    href: "/docs/credential-badges",
+    cta: "Explore badges",
+  },
 ];
+
+/* The cards render in a single row, so the column count must track
+   ENTRIES.length — otherwise an added card wraps and the single-row border
+   rules (border-r on :not(:last-child), no border-b at sm) leave a dangling
+   divider. Literal class strings keep Tailwind's JIT happy. */
+const GRID_COLS: Record<number, string> = {
+  3: "sm:grid-cols-3",
+  4: "sm:grid-cols-4",
+  5: "sm:grid-cols-5",
+  6: "sm:grid-cols-6",
+};
 
 export default function HomePage() {
   return (
@@ -71,7 +89,9 @@ export default function HomePage() {
       </section>
 
       {/* ── Quick paths ────────────────────────────────────────── */}
-      <section className="grid gap-px sm:grid-cols-4">
+      <section
+        className={`grid gap-px ${GRID_COLS[ENTRIES.length] ?? "sm:grid-cols-4"}`}
+      >
         {ENTRIES.map((e) => (
           <Link
             key={e.n}

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -63,23 +63,15 @@ export default function HomePage() {
           docs, or pick a section below.
         </p>
 
-        <LargeSearchToggle className="mt-8 w-full max-w-xl" />
+        <Link
+          href="/docs/getting-started"
+          className="mt-8 flex w-fit items-center gap-2 bg-foreground px-5 py-3 font-mono text-[11px] uppercase tracking-[0.14em] text-background transition-opacity hover:opacity-90"
+        >
+          Quickstart
+          <span aria-hidden>&rarr;</span>
+        </Link>
 
-        <p className="mt-4 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
-          New here?{" "}
-          <Link href="/docs/getting-started" className="text-brand hover:underline">
-            Start with the Quickstart &rarr;
-          </Link>
-          <span aria-hidden className="px-2 text-border">
-            /
-          </span>
-          <Link
-            href="https://api.andamio.io"
-            className="text-foreground hover:underline"
-          >
-            API Reference &#8599;
-          </Link>
-        </p>
+        <LargeSearchToggle className="mt-4 w-full max-w-xl" />
       </section>
 
       {/* ── Browse by section (the six-root spine) ─────────────── */}

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -26,6 +26,13 @@ const ENTRIES = [
     href: "https://api.andamio.io",
     cta: "Open the API docs",
   },
+  {
+    n: "04",
+    title: "Issuer",
+    body: "Issue and manage on-chain credentials with a low-code, API-backed product.",
+    href: "/docs/issuer",
+    cta: "Explore Issuer",
+  },
 ];
 
 export default function HomePage() {
@@ -64,7 +71,7 @@ export default function HomePage() {
       </section>
 
       {/* ── Quick paths ────────────────────────────────────────── */}
-      <section className="grid gap-px sm:grid-cols-3">
+      <section className="grid gap-px sm:grid-cols-4">
         {ENTRIES.map((e) => (
           <Link
             key={e.n}

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -116,7 +116,7 @@ export default function HomePage() {
 
       {/* ── Quiet meta line ────────────────────────────────────── */}
       <div className="py-8 font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
-        Live on Cardano mainnet &middot; Audited by TxPipe
+        Andamio Documentation &#124; 2026
       </div>
     </main>
   );

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,133 +1,121 @@
 import Link from "next/link";
+import { LargeSearchToggle } from "fumadocs-ui/components/layout/search-toggle";
 
-/* Editorial home page — the bold front door. Mono kicker + Sora headline in
-   docs' own tokens, then a few quick, low-friction calls to action. Static /
-   CSS-only; the calm reading experience lives behind /docs and is untouched. */
+/* Documentation entry point — search-forward, then a browse-by-section index
+   that mirrors the six-root IA spine. Editorial brand tokens (mono kickers,
+   Sora display, thin rules) are kept; the marketing chrome (oversized hero,
+   ghost numerals, CTA buttons, trust footer) is dialed down so the page reads
+   as an index, not a landing page. */
 
-const ENTRIES = [
+/* The six roots. api/, apps-tooling/, and developer-community/ do not exist as
+   routes yet — they are created in the Phase 2 IA restructure (Phase C). Until
+   then each card targets the root's best current page, which stays correct once
+   the restructure's permanent redirects land. */
+const SECTIONS = [
   {
-    n: "01",
+    kicker: "Product",
+    title: "Andamio API",
+    body: "REST endpoints and guides to build on the protocol from your own stack.",
+    href: "/docs/getting-started",
+  },
+  {
+    kicker: "Product",
+    title: "Andamio Issuer",
+    body: "Issue and manage credentials with a low-code, API-backed product.",
+    href: "/docs/issuer",
+  },
+  {
+    kicker: "Product",
+    title: "Credential Badges",
+    body: "Verifiable, on-chain badges that learners carry anywhere.",
+    href: "/docs/credential-badges",
+  },
+  {
+    kicker: "Zone",
+    title: "Apps & Tooling",
+    body: "Explore the app, plus the CLI, SDK, templates, bot, and Andamioscan.",
+    href: "/docs/guides",
+  },
+  {
+    kicker: "Zone",
+    title: "Developer Community",
+    body: "Pioneers, the repositories index, and community tools.",
+    href: "/docs/pioneers",
+  },
+  {
+    kicker: "Reference",
     title: "Protocol",
     body: "Validators, transactions, and tokens — the on-chain machinery, specified.",
     href: "/docs/protocol",
-    cta: "Read the protocol",
-  },
-  {
-    n: "02",
-    title: "Guides",
-    body: "Build, publish, and verify on Andamio with step-by-step walkthroughs.",
-    href: "/docs",
-    cta: "Start building",
-  },
-  {
-    n: "03",
-    title: "API Reference",
-    body: "REST endpoints to issue, verify, and gate on credentials from your own stack.",
-    href: "https://api.andamio.io",
-    cta: "Open the API docs",
-  },
-  {
-    n: "04",
-    title: "Issuer",
-    body: "Issue and manage on-chain credentials with a low-code, API-backed product.",
-    href: "/docs/issuer",
-    cta: "Explore Issuer",
-  },
-  {
-    n: "05",
-    title: "Credential Badges",
-    body: "Issue verifiable, on-chain credential badges that learners carry anywhere.",
-    href: "/docs/credential-badges",
-    cta: "Explore badges",
   },
 ];
-
-/* The cards render in a single row, so the column count must track
-   ENTRIES.length — otherwise an added card wraps and the single-row border
-   rules (border-r on :not(:last-child), no border-b at sm) leave a dangling
-   divider. Literal class strings keep Tailwind's JIT happy. */
-const GRID_COLS: Record<number, string> = {
-  3: "sm:grid-cols-3",
-  4: "sm:grid-cols-4",
-  5: "sm:grid-cols-5",
-  6: "sm:grid-cols-6",
-};
 
 export default function HomePage() {
   return (
     <main className="mx-auto w-full max-w-5xl px-6 sm:px-10">
-      {/* ── Hero ───────────────────────────────────────────────── */}
-      <section className="border-b border-border py-16 sm:py-24">
-        <div className="flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.18em] text-brand">
-          <span>Andamio / Documentation</span>
-          <span aria-hidden className="h-px flex-1 bg-border" />
-        </div>
-
-        <h1 className="mt-10 max-w-3xl font-display text-5xl font-bold leading-[1.02] tracking-[-0.03em] text-foreground sm:text-7xl">
+      {/* ── Hero: orient, then search ──────────────────────────── */}
+      <section className="py-14 sm:py-20">
+        <h1 className="max-w-3xl font-display text-4xl font-bold leading-[1.05] tracking-[-0.02em] text-foreground sm:text-5xl">
           Build on <span className="text-brand">Andamio</span>
         </h1>
-        <p className="mt-6 max-w-xl text-lg font-light leading-relaxed text-muted-foreground">
-          Issue verifiable, on-chain credentials. Pick where to start — you can
-          go deeper from anywhere.
+        <p className="mt-4 max-w-xl text-base font-light leading-relaxed text-muted-foreground">
+          Everything to issue, verify, and gate on-chain credentials. Search the
+          docs, or pick a section below.
         </p>
 
-        <div className="mt-8 flex flex-wrap gap-px">
-          <Link
-            href="/docs"
-            className="inline-flex items-center gap-2 bg-foreground px-5 py-3 font-mono text-[11px] uppercase tracking-[0.14em] text-background transition-opacity hover:opacity-90"
-          >
-            Get Started
-            <span aria-hidden>&rarr;</span>
+        <LargeSearchToggle className="mt-8 w-full max-w-xl" />
+
+        <p className="mt-4 font-mono text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+          New here?{" "}
+          <Link href="/docs/getting-started" className="text-brand hover:underline">
+            Start with the Quickstart &rarr;
           </Link>
+          <span aria-hidden className="px-2 text-border">
+            /
+          </span>
           <Link
             href="https://api.andamio.io"
-            className="inline-flex items-center px-5 py-3 font-mono text-[11px] uppercase tracking-[0.14em] text-foreground ring-1 ring-inset ring-border transition-colors hover:bg-accent"
+            className="text-foreground hover:underline"
           >
-            API Reference
+            API Reference &#8599;
           </Link>
-        </div>
+        </p>
       </section>
 
-      {/* ── Quick paths ────────────────────────────────────────── */}
-      <section
-        className={`grid gap-px ${GRID_COLS[ENTRIES.length] ?? "sm:grid-cols-4"}`}
-      >
-        {ENTRIES.map((e) => (
-          <Link
-            key={e.n}
-            href={e.href}
-            className="group relative flex flex-col overflow-hidden border-b border-border py-10 sm:border-b-0 sm:py-14 sm:pr-8 sm:[&:not(:first-child)]:pl-8 sm:[&:not(:last-child)]:border-r"
-          >
-            <span
-              aria-hidden
-              className="pointer-events-none absolute -top-2 right-2 font-display text-7xl font-bold tabular-nums tracking-[-0.05em] text-foreground/[0.04] sm:text-8xl"
+      {/* ── Browse by section (the six-root spine) ─────────────── */}
+      <section>
+        <div className="mb-4 font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
+          Browse by section
+        </div>
+        <div className="grid grid-cols-1 border-l border-t border-border sm:grid-cols-2 lg:grid-cols-3">
+          {SECTIONS.map((s) => (
+            <Link
+              key={s.title}
+              href={s.href}
+              className="group relative flex flex-col border-b border-r border-border p-6 transition-colors hover:bg-accent sm:p-7"
             >
-              {e.n}
-            </span>
-            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-muted-foreground">
-              {e.n}
-            </span>
-            <h2 className="mt-3 font-display text-2xl font-semibold tracking-tight text-foreground">
-              {e.title}
-            </h2>
-            <p className="mt-2 max-w-xs text-sm font-light leading-relaxed text-muted-foreground">
-              {e.body}
-            </p>
-            <span className="mt-5 inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-brand">
-              {e.cta}
               <span
                 aria-hidden
-                className="transition-transform group-hover:translate-x-0.5"
+                className="absolute right-5 top-6 font-mono text-sm text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-brand"
               >
                 &rarr;
               </span>
-            </span>
-          </Link>
-        ))}
+              <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+                {s.kicker}
+              </span>
+              <h2 className="mt-2 font-display text-xl font-semibold tracking-tight text-foreground">
+                {s.title}
+              </h2>
+              <p className="mt-2 max-w-[26ch] text-sm font-light leading-relaxed text-muted-foreground">
+                {s.body}
+              </p>
+            </Link>
+          ))}
+        </div>
       </section>
 
-      {/* ── Footer caption ─────────────────────────────────────── */}
-      <div className="border-t border-border py-6 font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+      {/* ── Quiet meta line ────────────────────────────────────── */}
+      <div className="py-8 font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
         Live on Cardano mainnet &middot; Audited by TxPipe
       </div>
     </main>

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,11 +1,10 @@
 import Link from "next/link";
-import { LargeSearchToggle } from "fumadocs-ui/components/layout/search-toggle";
 
-/* Documentation entry point — search-forward, then a browse-by-section index
-   that mirrors the six-root IA spine. Editorial brand tokens (mono kickers,
-   Sora display, thin rules) are kept; the marketing chrome (oversized hero,
-   ghost numerals, CTA buttons, trust footer) is dialed down so the page reads
-   as an index, not a landing page. */
+/* Documentation entry point — a single Quickstart CTA over a browse-by-section
+   index that mirrors the six-root IA spine. Editorial brand tokens (mono
+   kickers, Inter display, thin rules) are kept; the marketing chrome (oversized
+   hero, ghost numerals, eyebrow, trust footer) is dialed down so the page reads
+   as an index, not a landing page. Top-nav search covers find — no in-page box. */
 
 /* The six roots. api/, apps-tooling/, and developer-community/ do not exist as
    routes yet — they are created in the Phase 2 IA restructure (Phase C). Until
@@ -55,23 +54,21 @@ export default function HomePage() {
     <main className="mx-auto w-full max-w-5xl px-6 sm:px-10">
       {/* ── Hero: orient, then search ──────────────────────────── */}
       <section className="py-14 sm:py-20">
-        <h1 className="max-w-3xl font-display text-4xl font-bold leading-[1.05] tracking-[-0.02em] text-foreground sm:text-5xl">
-          Build on <span className="text-brand">Andamio</span>
+        <h1 className="max-w-3xl font-display text-4xl font-semibold leading-[0.95] tracking-[-0.045em] text-foreground sm:text-5xl">
+          Build on Andamio
         </h1>
         <p className="mt-4 max-w-xl text-base font-light leading-relaxed text-muted-foreground">
-          Everything to issue, verify, and gate on-chain credentials. Search the
-          docs, or pick a section below.
+          Everything to issue, verify, and gate on-chain credentials. Pick a
+          section below to dive in.
         </p>
 
         <Link
           href="/docs/getting-started"
-          className="mt-8 flex w-fit items-center gap-2 bg-foreground px-5 py-3 font-mono text-[11px] uppercase tracking-[0.14em] text-background transition-opacity hover:opacity-90"
+          className="mt-8 flex w-fit items-center gap-2 bg-brand px-5 py-3 font-mono text-[11px] uppercase tracking-[0.14em] text-brand-foreground transition-opacity hover:opacity-90"
         >
           Quickstart
           <span aria-hidden>&rarr;</span>
         </Link>
-
-        <LargeSearchToggle className="mt-4 w-full max-w-xl" />
       </section>
 
       {/* ── Browse by section (the six-root spine) ─────────────── */}
@@ -88,7 +85,7 @@ export default function HomePage() {
             >
               <span
                 aria-hidden
-                className="absolute right-5 top-6 font-mono text-sm text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-brand"
+                className="absolute right-5 top-6 font-mono text-sm text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground"
               >
                 &rarr;
               </span>

--- a/app/global.css
+++ b/app/global.css
@@ -7,10 +7,14 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-mona);
-  --font-heading: var(--font-mona); /* one neutral family (Stripe model) — headings = body @ 600. In-article + page titles stay here. */
-  --font-display: var(--font-sora); /* Sora — applied surgically (editorial home page only), never via --font-heading */
-  --font-mono: var(--font-geist-mono);
+  /* Brand canon (andamio-brand-guide.md §4): Inter for all sans, JetBrains
+     Mono for labels/data. One neutral family (Stripe model) — in-article
+     headings = body @ 600; the editorial home uses --font-display (also Inter)
+     at weight 600 / tracking -0.045em per the brand "12 cut". */
+  --font-sans: var(--font-inter);
+  --font-heading: var(--font-inter);
+  --font-display: var(--font-inter);
+  --font-mono: var(--font-jetbrains-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -154,9 +158,9 @@
 
   body {
     @apply bg-background text-foreground;
-    /* Grayscale smoothing renders Mona Sans noticeably lighter/cleaner on
-       macOS (subpixel rendering otherwise fattens every stroke). A big part
-       of the "premium" feel. */
+    /* Grayscale smoothing renders Inter noticeably lighter/cleaner on macOS
+       (subpixel rendering otherwise fattens every stroke). A big part of the
+       "premium" feel. */
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
@@ -250,9 +254,9 @@
   }
 
   /* Compact body rhythm (Stripe-style density) + lighter body weight.
-     Mona Sans Light (300) for running text reads thinner/more refined; a
-     slightly softened ink keeps it legible without going heavy. Headings,
-     links, and strong text restore their own weight below. */
+     Inter Light (300) for running text reads thinner/more refined; a slightly
+     softened ink keeps it legible without going heavy. Headings, links, and
+     strong text restore their own weight below. */
   .prose {
     font-size: 0.9375rem;  /* 15px */
     font-weight: 300;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,38 +1,31 @@
 import './global.css';
 import { RootProvider } from 'fumadocs-ui/provider';
-import localFont from 'next/font/local';
-import { Sora } from 'next/font/google';
-import { GeistMono } from 'geist/font/mono';
+import { Inter, JetBrains_Mono } from 'next/font/google';
 import type { ReactNode } from 'react';
 
-// Body: Mona Sans (GitHub's industrial grotesque) — self-hosted, OFL.
-const monaSans = localFont({
-  variable: '--font-mona',
-  display: 'swap',
-  src: [
-    { path: './fonts/MonaSans-Light.woff2', weight: '300', style: 'normal' },
-    { path: './fonts/MonaSans-Regular.woff2', weight: '400', style: 'normal' },
-    { path: './fonts/MonaSans-Medium.woff2', weight: '500', style: 'normal' },
-    { path: './fonts/MonaSans-SemiBold.woff2', weight: '600', style: 'normal' },
-    { path: './fonts/MonaSans-Bold.woff2', weight: '700', style: 'normal' },
-  ],
-});
-
-// Display: Sora — the marketing site's headline face. Wired as a CSS variable
-// so it can be applied surgically (the editorial home page only). Body and
-// in-article headings stay on Mona Sans via --font-heading.
-const sora = Sora({
-  variable: '--font-sora',
+// Brand canon (andamio-brand-guide.md §4, locked 2026-06-28):
+//   Sans (display + UI) = Inter; Mono = JetBrains Mono. Never a serif.
+// Loaded as CSS variables and consumed by --font-sans / --font-heading /
+// --font-display / --font-mono in global.css. Inter and JetBrains Mono are
+// variable fonts, so the full weight axis (incl. the 300 body and 600
+// display weights the brand calls for) is available without listing weights.
+const inter = Inter({
+  variable: '--font-inter',
   display: 'swap',
   subsets: ['latin'],
-  weight: ['600', '700'],
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: '--font-jetbrains-mono',
+  display: 'swap',
+  subsets: ['latin'],
 });
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`${monaSans.variable} ${sora.variable} ${GeistMono.variable} ${monaSans.className}`}
+      className={`${inter.variable} ${jetbrainsMono.variable} ${inter.className}`}
       suppressHydrationWarning
     >
       <body className="flex flex-col min-h-screen">

--- a/docs/plans/2026-06-29-001-feat-docs-phase2-six-root-ia-plan.md
+++ b/docs/plans/2026-06-29-001-feat-docs-phase2-six-root-ia-plan.md
@@ -1,0 +1,276 @@
+---
+title: "feat: Docs Phase 2 IA — roadmap-aligned six-root spine"
+type: feat
+status: active
+date: 2026-06-29
+---
+
+# feat: Docs Phase 2 IA — roadmap-aligned six-root spine
+
+## Summary
+
+Restructure the docs sidebar around **six product roots** that mirror the #28 Roadmap initiatives (API · Issuer · Credential Badges · Apps & Tooling · Developer Community · Protocol), replacing the flat front-door `meta.json` and the older `ecosystem/`+`app/` model in the governance plan. A mechanism spike proves Fumadocs root-scoping works before any content moves; content then migrates into `root: true` folders with a permanent redirect per moved URL. Two side quests ship independently: revising the governance docs to the six-root model, and adding an Issuer card to the home page.
+
+## Problem Frame
+
+The docs IA does not match how the product is described on the #28 Roadmap, and the checked-in Phase-2 plan (`.claude/skills/docs-governance/phase-2-ia-restructure.md`) targets an invented `ecosystem/`+`app/` structure with several still-open decisions. Meanwhile the live sidebar is a single flat tree with `--- separator ---` sections (`content/docs/meta.json`): there is no product scoping, so a reader in "Andamio API" sees the entire site. The roadmap-aligned decision is made (six roots, locked placements) — this plan is execution, not a re-open. It originates from the orch Phase-2 IA sign-off handoff (2026-06-29), which governs `.claude/skills/docs-governance/`.
+
+The one real unknown the handoff names — *does a `root: true` folder plus auto-derived tabs actually scope the sidebar?* — is **de-risked by research** (see KTD1): Fumadocs scopes the tree automatically via `TreeContext`, independent of the tabs array. The spike still runs as a hard gate to confirm the behavior end-to-end before content churns.
+
+---
+
+## Requirements
+
+### IA spine and scoping
+- R1. The six sidebar roots mirror the #28 Roadmap initiative names: Andamio API, Andamio Issuer, Credential Badges, Apps & Tooling, Developer Community, Protocol.
+- R2. Landing on `/docs` shows a neutral front door with **no product preselected** (the tree root, no `root: true` folder in the active path).
+- R3. Entering any product root scopes the sidebar to that root's pages only; the root toggle (dropdown) lists all six roots and highlights the active one.
+- R4. Cross-cutting content (Glossary, Light Paper) is surfaced in a front-door / Reference zone, **not** as roots, and stays woven per the locked papers decision (landing page remains the papers' artifact home).
+
+### Content migration safety
+- R5. Every moved URL has a `permanent: true` redirect in `next.config.mjs`, generated from a pre/post route diff.
+- R6. No in-repo `/docs/...` link points at a moved-away URL after migration (the build does not catch these — content-collections silently 404s).
+- R7. Path-hardcoded tooling continues to work: `npm run docs-coverage`, `npm run docs-drift`, and the audit skills that reference `content/docs/...` paths are updated to the new layout.
+- R8. Search rebuilds from content and returns results for moved pages.
+
+### Governance alignment
+- R9. `docs-governance` SKILL.md, `phase-2-ia-restructure.md`, and `tool-registry.md` describe the six-root spine; the stale four-job / `ecosystem/`+`app/` model and the now-answered open decisions are removed.
+- R10. Tool placements in `tool-registry.md` reflect: Andamio Bot · CLI · App Template · SDK · Andamioscan → Apps & Tooling; Pioneers · Repositories → Developer Community.
+
+### Front door
+- R11. The home page (`app/(home)/page.tsx`) shows an Issuer card alongside the existing entries so the front door matches the spine.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Tree scoping is automatic and independent of the tabs array — correcting the handoff's premise.** Fumadocs (`fumadocs-ui` 15.4.1) scopes the sidebar in `contexts/tree.js`: it runs `searchPath(tree, pathname)` then `path.findLast(item => item.type === 'folder' && item.root)` and renders only that folder's children. `RootToggle` + the `urls` set only drive the dropdown **selector and active-highlight** — they never filter the tree. Consequence: a folder with `root: true` already gets a scoped subtree today (protocol/ does). The handoff's "manual tabs carry no `urls` set so the tree isn't filtered" is imprecise — the tree filtering was never the tabs' job. The implementer should not hunt for a `urls`-based tree filter; it does not exist.
+- KTD2. **Use auto-derived tabs, not a hand-call to `getSidebarTabs`.** Replace the hand-written `sidebar.tabs` array in `app/docs/layout.tsx` with `sidebar={{ tabs: true }}` (or omit the key). `DocsLayout` calls `getSidebarTabs(tree)` internally, walking the tree for `root: true` folders and computing each tab's `urls` set. This fixes dropdown correctness (all six roots listed, robust active-highlight) with no manual registry to maintain.
+- KTD3. **Spike proves scoping across two roots before any content move.** Per the chosen approach, stand up a minimal `api/` root **alongside** the existing `protocol/` root and switch to auto-derived tabs. This proves (a) `/docs` neutral front door, (b) two independent roots each scope correctly, (c) the dropdown lists both — the closest proof to the real six-root end state. The spike is a **hard gate**: if scoping does not behave, stop and report before touching content.
+- KTD4. **Tools move to Apps & Tooling, superseding the old "API → Tools" placement.** The prior governance put CLI/App Template/SDK/Andamioscan under API → Tools. The roadmap model places them under the **Apps & Tooling** root. The handoff is authoritative; the governance docs are reconciled to match (R10). Andamio Bot lives *inside* Apps & Tooling (it is an app on the roadmap), not a sold-product peer — preserving the "no tool is a product peer" principle.
+- KTD5. **Redirects are generated from a route diff, not hand-listed.** Capture the route list before and after the move (e.g. from the built route manifest / a content-collections page enumeration) and emit one `permanent: true` redirect per delta. Hand-listing invites omissions; the existing `next.config.mjs` redirects block is the insertion point and already carries the `/docs/andamio-issuer` and `/docs/repositories/*` precedents.
+- KTD6. **Protocol contents are out of scope.** This plan stands up the `protocol/` root (already `root: true`) but does not triage `protocol/v2/*` (state-machine, transactions, validators, tokens) or relocate the Understand cluster (`whats-new`, `cost-estimation`, `security-audit`). Those stay where they are for a separate workstream.
+
+---
+
+## High-Level Technical Design
+
+Target sidebar spine (six roots; cross-cutting items are front-door references, not roots):
+
+```mermaid
+flowchart TB
+  FD["/docs — neutral front door<br/>(tree root, no product preselected)"]
+  FD --> API["api/ (root)<br/>Andamio API"]
+  FD --> ISS["issuer/ (root)<br/>Andamio Issuer"]
+  FD --> CB["credential-badges/ (root)<br/>Credential Badges"]
+  FD --> AT["apps-tooling/ (root)<br/>Explore the App · Bot · CLI<br/>App Template · SDK · Andamioscan"]
+  FD --> DC["developer-community/ (root)<br/>Pioneers · Repositories"]
+  FD --> PROT["protocol/ (root)<br/>internals — contents NOT triaged"]
+  FD -. referenced, not a root .-> XREF["Reference zone:<br/>Glossary · Light Paper"]
+```
+
+How a request resolves to a scoped sidebar (the mechanism from KTD1, unchanged by this work — only the set of `root: true` folders grows):
+
+```mermaid
+sequenceDiagram
+  participant U as Request /docs/api/quickstart
+  participant TC as TreeContext (tree.js)
+  participant SB as SidebarPageTree
+  participant RT as RootToggle (tabs)
+  U->>TC: searchPath(tree, pathname)
+  TC->>TC: findLast(folder.root === true) → api/ folder
+  TC->>SB: provide scoped root = api/
+  SB->>SB: render only api/ children
+  RT->>RT: match pathname against each tab's urls set → highlight "Andamio API"
+  Note over U,RT: /docs (no root in path) → falls back to tree root → neutral front door
+```
+
+---
+
+## Scope Boundaries
+
+### In scope
+- Six `root: true` folders, neutral front door, auto-derived tabs, content moves, redirects, link fixes, tooling updates, search verification, governance-doc revision, home-page Issuer card.
+
+### Deferred to follow-up work
+- Intra-`api/` and intra-`apps-tooling/` page-placement fine-tuning where soft (see content-move table notes on `building-on-andamio`, `demo`, `reference`). Reasonable calls are made here; revisit if they read wrong in situ.
+
+### Out of scope (separate workstreams — do NOT do here)
+- **Protocol deep triage** — contents of `protocol/v2/*` and the Understand cluster placement (`whats-new`, `cost-estimation`, `security-audit`). `security-audit`/contract-verification may later also surface under API, but that is decided in the triage, not here.
+- **De-genericize the 45 token/validator stubs** — mostly under `protocol/v2/`, overlaps with the triage above.
+
+---
+
+## Content moves (today → target root)
+
+Authoritative membership is the six-root spine; per-page placement below is execution detail. `(soft)` = reasonable call, revisit if wrong in situ.
+
+| Today | Target |
+|---|---|
+| `content/docs/getting-started.mdx` | `api/` |
+| `content/docs/guides/developers/*` (excl. `cli/`) | `api/` |
+| `content/docs/guides/developers/api-quickstart` | `api/` (e.g. `api/quickstart`) |
+| `content/docs/reference/` | `api/reference/` (soft) |
+| `content/docs/building-on-andamio.mdx` | `api/` — conceptual intro (soft) |
+| `content/docs/guides/courses`, `guides/projects`, `guides/contributors` | `apps-tooling/` (Explore the App path) |
+| `content/docs/demo.mdx` | `apps-tooling/` (soft) |
+| `content/docs/guides/developers/cli/` | `apps-tooling/` (CLI is an Apps & Tooling tool, not API) |
+| `content/docs/sdk/` | `apps-tooling/` |
+| Andamioscan · App Template · Andamio Bot (tool pages where they exist) | `apps-tooling/` |
+| `content/docs/pioneers/` | `developer-community/` |
+| `content/docs/repositories.mdx` | `developer-community/` |
+| `content/docs/issuer/` | stays — add `root: true` |
+| `content/docs/credential-badges/` | stays — add `root: true` |
+| `content/docs/protocol/` | stays — already `root: true`, contents untouched |
+| `content/docs/glossary.mdx`, `content/docs/light-paper.mdx` | stay top-level; surfaced in front-door Reference zone (no move) |
+
+Tools without an existing page (Bot, App Template, Andamioscan if absent) are **registered** in the `apps-tooling/` meta and `tool-registry.md` only — no stub pages created here.
+
+---
+
+## Implementation Units
+
+Units are phased: **Phase A** (U1–U2) is independent and ships first; **Phase B** (U3) is the gate; **Phase C** (U4–U9) runs only after the gate proves out.
+
+### U1. Add Issuer card to the home page
+- **Goal:** Front door matches the spine — Issuer is present alongside the existing paths (R11).
+- **Requirements:** R11
+- **Dependencies:** none (independent of all IA work)
+- **Files:** `app/(home)/page.tsx`
+- **Approach:** Add an Issuer entry to the `ENTRIES` array (title "Issuer", a one-line low-code-product body, `href: "/docs/issuer"`, a CTA). Four entries no longer fit `sm:grid-cols-3` cleanly — adjust the grid (e.g. `sm:grid-cols-2` for a 2×2, or `sm:grid-cols-4`) and renumber the `n` kickers. Keep the existing editorial token system (mono kicker, `font-display`, border-grid hover). Static/CSS-only; do not touch `/docs`.
+- **Patterns to follow:** the existing `ENTRIES.map` card pattern and the `border-r`/`border-b` grid-line styling already in the file.
+- **Test scenarios:** Test expectation: none (static presentational change). Verify visually: four cards render, the Issuer card links to `/docs/issuer`, the grid is balanced at `sm` and stacks on mobile.
+- **Verification:** `npm run dev`, load `/`, confirm the Issuer card appears, links correctly, and the grid layout holds at mobile and `sm`+ widths.
+
+### U2. Revise governance docs to the six-root spine
+- **Goal:** `docs-governance` describes the six-root model; stale four-job / `ecosystem/`+`app/` content and answered open decisions are gone (R9, R10).
+- **Requirements:** R9, R10
+- **Dependencies:** none (documentation-only; independent of the mechanism)
+- **Files:** `.claude/skills/docs-governance/SKILL.md`, `.claude/skills/docs-governance/phase-2-ia-restructure.md`, `.claude/skills/docs-governance/tool-registry.md`
+- **Approach:** Reconcile, do not append.
+  - SKILL.md — rewrite "Context: the spine the rules protect" and "The principle": the spine is now the six roadmap initiatives. Keep the principle that no single **tool** is a sold-product peer, but acknowledge two category/zone roots (Apps & Tooling, Developer Community) plus Credential Badges. The Bot lives *inside* Apps & Tooling.
+  - `phase-2-ia-restructure.md` — replace the `ecosystem/`+`app/` target structure and content-move table with the six-root spine + the move table from this plan. Drop the now-answered open decisions (#2 App, #3 Bot, #4 glossary/papers). Mark the Understand cluster (#5) and all `protocol/` contents **out of scope — deferred to a separate Protocol deep-triage workstream**.
+  - `tool-registry.md` — set Andamio Bot `Serves: Apps & Tooling` (move it out of "Unplaced"); set CLI / App Template / SDK / Andamioscan rows to Apps & Tooling; note Pioneers / Repositories under Developer Community.
+- **Patterns to follow:** existing table shapes and the cross-links between the three governance files (keep them consistent after the rewrite).
+- **Test scenarios:** Test expectation: none (skill/markdown docs, no runtime behavior). Cross-check: no remaining reference to `ecosystem/` or a standalone `app/` root; the three files agree on root names and tool placements.
+- **Verification:** Re-read all three files; confirm internal links still resolve and no stale model survives.
+
+### U3. Mechanism spike — prove dual-root scoping (HARD GATE)
+- **Goal:** Demonstrate that `root: true` + auto-derived tabs scopes the sidebar, across two roots, with a neutral front door (R2, R3) — before any content moves.
+- **Requirements:** R2, R3 (proof-of-mechanism)
+- **Dependencies:** none; **blocks U4–U9**
+- **Files:** `app/docs/layout.tsx`, `content/docs/api/meta.json` (new), `content/docs/api/index.mdx` (new, minimal), `content/docs/protocol/meta.json` (already `root: true` — no change expected)
+- **Approach:** Replace the hand-written `sidebar.tabs` array with `sidebar={{ tabs: true }}` (auto-derive — KTD2). Stand up a minimal `api/` root: `content/docs/api/meta.json` with `{ "title": "Andamio API", "root": true, ... }` and a stub `index.mdx` plus one or two throwaway child pages so scoping is observable. Leave `protocol/` as-is. Do **not** move real content yet. After verifying, the stub `api/` either seeds U5 or is discarded — decide at U4.
+- **Patterns to follow:** `content/docs/protocol/meta.json` as the `root: true` meta shape; `lib/source.ts` for how the tree is built (no change expected).
+- **Test scenarios:**
+  - Happy path: load `/docs` → neutral front door, no product preselected, dropdown shows roots without one being forced active.
+  - Scoping: enter a `protocol/` page → sidebar shows only protocol children; enter the `api/` stub → sidebar shows only api children.
+  - Dropdown: the root toggle lists both "Andamio API" and "Protocol" and highlights the one matching the current path (covers the `urls`-set highlight from KTD1).
+  - Negative/gate: if entering a root does **not** scope the tree, treat as gate failure — stop and report rather than proceeding.
+- **Verification:** `npm run dev`; manually walk the three scenarios above. Gate decision recorded: pass → proceed to Phase C; fail → stop and report (do not touch content).
+
+### U4. Neutral front door + scaffold the six roots
+- **Goal:** Convert the flat separator-based front door into a neutral front door plus six `root: true` folders ready to receive content (R1, R2, R4).
+- **Requirements:** R1, R2, R4
+- **Dependencies:** U3 (gate must pass)
+- **Files:** `content/docs/meta.json`, `content/docs/api/meta.json`, `content/docs/apps-tooling/meta.json` (new), `content/docs/developer-community/meta.json` (new), `content/docs/issuer/meta.json`, `content/docs/credential-badges/meta.json`, `content/docs/protocol/meta.json`
+- **Approach:** Rewrite `content/docs/meta.json` as a neutral front door: top-level entry points + a **Reference zone** that surfaces Glossary and Light Paper (which stay top-level, not roots — R4), dropping the `--- separator ---` product sections now owned by roots. Add `root: true` to `issuer/` and `credential-badges/` meta. Create `apps-tooling/` and `developer-community/` folders with `root: true` meta (titles "Apps & Tooling", "Developer Community") and an index page each. Promote the `api/` stub from U3 to a real root meta (or create it if discarded). Keep `protocol/` untouched.
+- **Patterns to follow:** `content/docs/protocol/meta.json` (`root`, `icon`, `defaultOpen`); existing `content/docs/meta.json` link-item syntax (`[Label](/path)`, `--- separators ---`) for the front-door composition.
+- **Test scenarios:**
+  - Front door: `/docs` lists the six roots as entry points + the Reference zone (Glossary, Light Paper) with no product preselected.
+  - Each new/flipped root folder appears in the auto-derived dropdown.
+  - MDX integrity: after editing meta, confirm pages still resolve — `grep` the moved/affected slugs in `.content-collections/generated/allDocs.js` (content-collections silently drops invalid frontmatter → 404).
+- **Verification:** `npm run dev`; `/docs` is neutral; all six roots show in the toggle; no console/build warnings about missing pages.
+
+### U5. Move content into `api/`
+- **Goal:** API developer content lives under the `api/` root (R1).
+- **Requirements:** R1
+- **Dependencies:** U4
+- **Files:** moves of `content/docs/getting-started.mdx`, `content/docs/guides/developers/*` (excl. `cli/`), `content/docs/guides/developers/api-quickstart`, `content/docs/reference/`, `content/docs/building-on-andamio.mdx` into `content/docs/api/...`; plus `content/docs/api/meta.json` ordering.
+- **Approach:** Relocate per the content-move table. Preserve each page's frontmatter exactly (em dashes fine; never `replace_all` across `---` fences — see CLAUDE.md MDX gotchas). Update `api/meta.json` page ordering. Record old→new URL pairs for U8 as you go.
+- **Patterns to follow:** existing `guides/developers/meta.json` and `reference/meta.json` for sub-folder meta shape.
+- **Test scenarios:**
+  - Each moved page renders at its new URL and is scoped under `api/` in the sidebar.
+  - `grep` each moved slug in `.content-collections/generated/allDocs.js` to confirm it was not silently dropped.
+  - `building-on-andamio` and `reference` (the soft placements) read sensibly under `api/`.
+- **Verification:** `npm run dev`; navigate each new `api/` URL; sidebar scopes to `api/`.
+
+### U6. Move content into `apps-tooling/`
+- **Goal:** Explore-the-App path and the Apps & Tooling tools live under `apps-tooling/` (R1, KTD4).
+- **Requirements:** R1
+- **Dependencies:** U4 (independent of U5; can land in parallel)
+- **Files:** moves of `content/docs/guides/courses`, `guides/projects`, `guides/contributors`, `content/docs/demo.mdx`, `content/docs/guides/developers/cli/`, `content/docs/sdk/` into `content/docs/apps-tooling/...`; `content/docs/apps-tooling/meta.json` ordering and tool registrations (Bot / App Template / Andamioscan as links where no page exists).
+- **Approach:** Relocate per the table. Note `cli/` is pulled out of `guides/developers/` (which otherwise goes to `api/` in U5) — sequence so the `cli/` move and the U5 developers move don't collide. For tools without pages, add registry entries / front-door links only (no stub pages). Record old→new URL pairs for U8.
+- **Patterns to follow:** `content/docs/sdk/meta.json` and `guides/*/meta.json` for sub-meta; `tool-registry.md` placements from U2.
+- **Test scenarios:**
+  - Platform guides (courses/projects/contributors), `demo`, `cli`, and `sdk` render under `apps-tooling/` and scope correctly.
+  - `cli/` no longer resolves under its old `guides/developers/` path (its redirect is verified in U8).
+  - `grep` moved slugs in `.content-collections/generated/allDocs.js`.
+- **Verification:** `npm run dev`; navigate the `apps-tooling/` subtree; sidebar scopes to `apps-tooling/`.
+
+### U7. Move content into `developer-community/`
+- **Goal:** Pioneers and Repositories live under `developer-community/` (R1, R10).
+- **Requirements:** R1, R10
+- **Dependencies:** U4 (independent of U5/U6)
+- **Files:** moves of `content/docs/pioneers/` and `content/docs/repositories.mdx` into `content/docs/developer-community/...`; `content/docs/developer-community/meta.json` ordering.
+- **Approach:** Relocate per the table. `pioneers/` carries its `live-coding/archive/...` subtree — move the whole folder and keep its internal meta intact. Record old→new URL pairs for U8 (note the existing `/docs/repositories/*` redirects already in `next.config.mjs` — they now point at the old `/docs/repositories`, which itself moves; chain or update them).
+- **Patterns to follow:** `content/docs/pioneers/meta.json` and the live-coding archive meta structure (see CLAUDE.md Pioneers archival section — paths there will need updating in U9).
+- **Test scenarios:**
+  - Pioneers archive index and session pages render under `developer-community/` and scope correctly.
+  - Repositories page renders under `developer-community/`.
+  - Existing `/docs/repositories/on-chain/*` etc. redirects still resolve (now via a chain to the new location).
+  - `grep` moved slugs in `.content-collections/generated/allDocs.js`.
+- **Verification:** `npm run dev`; navigate the `developer-community/` subtree; confirm old repository sub-URLs still redirect.
+
+### U8. Redirects for every moved URL
+- **Goal:** No moved URL 404s for external/inbound links (R5).
+- **Requirements:** R5
+- **Dependencies:** U5, U6, U7 (all moves complete)
+- **Files:** `next.config.mjs`
+- **Approach:** Generate a pre/post route diff (KTD5) — enumerate routes before the moves (from a clean build / content-collections page list captured at U4) and after, diff to get every changed URL. Add a `permanent: true` redirect per delta into the existing `redirects()` array. Reconcile the pre-existing `/docs/andamio-issuer` and `/docs/repositories/*` entries with the new structure (the repositories ones now need to chain to `developer-community/`). Use wildcard `:slug*` patterns where a whole folder moved.
+- **Patterns to follow:** the existing `redirects()` block in `next.config.mjs` (wildcard `:slug*`, `permanent: true`).
+- **Test scenarios:**
+  - For a sample of moved URLs across all three roots, requesting the old URL 308-redirects to the new one.
+  - Folder-wildcard moves (e.g. `guides/developers/*`, `sdk/*`, `pioneers/*`) redirect their children, not just the index.
+  - Pre-existing redirects still terminate at a live page (no redirect loops, no chains to a 404).
+- **Verification:** Build, then curl/load a sampled set of old URLs and confirm each lands on the new page; check for loops.
+
+### U9. Fix in-repo links, path-hardcoded tooling, and verify search
+- **Goal:** Internal links, tooling, and search all work post-migration (R6, R7, R8).
+- **Requirements:** R6, R7, R8
+- **Dependencies:** U5, U6, U7 (and ideally U8 for redirect cross-checks)
+- **Files:** any `content/docs/**/*.mdx` with `/docs/...` links to moved pages; `package.json` scripts / scripts behind `docs-coverage` and `docs-drift`; `.claude/skills/**` and `.claude/CLAUDE.md` references to moved `content/docs/...` paths (e.g. the Pioneers archival paths); search config if it pins paths.
+- **Approach:** `grep` the repo for `/docs/<moved>` links and `content/docs/<moved>` path references and update to new locations (the build will not catch stale `/docs/...` links — content-collections silently 404s). Update `npm run docs-coverage` / `docs-drift` and the audit skills to the new tree. Update CLAUDE.md's Pioneers archival paths and the V2 docs path references. Rebuild and verify search returns moved pages.
+- **Patterns to follow:** existing audit-skill path references; the `audit-docs` skill for how coverage/drift resolve paths.
+- **Test scenarios:**
+  - `grep` shows zero `/docs/<old-path>` links remaining in `content/docs/`.
+  - `npm run docs-coverage` and `npm run docs-drift` run without path errors.
+  - Search (`app/api/search/`) returns results for at least one moved page in each root.
+  - Spot-check internal cross-links from protocol/credential-badges pages into moved targets still resolve.
+- **Verification:** Run both `npm run` audit scripts; exercise search for moved pages; click through a sample of internal links.
+
+---
+
+## Risks & Dependencies
+
+- **Redirect omissions / SEO** — a missed moved URL 404s for inbound links. Mitigation: generate redirects from a route diff (KTD5), not by hand; sample-test across all roots (U8).
+- **Silent 404s from content-collections** — invalid frontmatter or stale links drop pages with no build error. Mitigation: `grep .content-collections/generated/allDocs.js` after every move (U5–U7) and `grep` for stale `/docs/...` links (U9).
+- **`cli/` move collision** — `cli/` leaves `guides/developers/` (→ `api/`) for `apps-tooling/`; sequence U5/U6 so the parent-folder move and the child extraction don't clobber each other.
+- **Redirect chains** — the existing `/docs/repositories/*` redirects target a path that itself moves; risk of chains or loops. Mitigation: reconcile them in U8 and test for loops.
+- **Tooling drift** — `docs-coverage`/`docs-drift` and audit skills hardcode `content/docs/...`; they silently mis-scan if not updated (U9, R7).
+- **Gate dependency** — U4–U9 must not start until U3 proves scoping. If U3 fails, stop and report; the restructure does not proceed.
+- **Fumadocs version pin** — findings are against `fumadocs-ui`/`fumadocs-core` 15.4.1; the tabs/RootToggle API has shifted across versions. A future upgrade could change auto-derive behavior.
+
+---
+
+## Sources & Research
+
+- **Origin:** orch Phase-2 IA sign-off handoff (2026-06-29) — "Docs Phase 2 IA, roadmap-aligned six-root spine." Governs `.claude/skills/docs-governance/`.
+- **Mechanism (KTD1/KTD2), verified in `node_modules` at v15.4.1:**
+  - `fumadocs-ui/dist/contexts/tree.js` — `searchPath` + `findLast(folder.root === true)` scopes the tree (the actual filter).
+  - `fumadocs-ui/dist/utils/get-sidebar-tabs.js` — walks the tree for `root: true` folders, builds each tab's `urls` Set via `getFolderUrls`.
+  - `fumadocs-ui/dist/components/layout/root-toggle.js` — uses `urls` only for dropdown active-highlight; does not filter the tree.
+  - `fumadocs-ui/dist/layouts/docs/shared.js` — `sidebar.tabs: true | undefined` auto-derives; an array is used verbatim.
+- **Current state:** `app/docs/layout.tsx` (hand-written tabs), `content/docs/meta.json` (flat separators), `content/docs/protocol/meta.json` (`root: true` already), `next.config.mjs` (existing redirects block), `lib/source.ts` (tree loader).
+- **Governance to revise:** `.claude/skills/docs-governance/{SKILL.md,phase-2-ia-restructure.md,tool-registry.md}`.
+- **MDX gotchas (CLAUDE.md):** content-collections silently drops invalid-frontmatter files; never `replace_all` across `---` fences; verify via `.content-collections/generated/allDocs.js`.


### PR DESCRIPTION
## Summary

Phase A of the roadmap-aligned **six-root docs IA** ([plan](docs/plans/2026-06-29-001-feat-docs-phase2-six-root-ia-plan.md)) — the work that's independent of the mechanism spike and ships on its own. The structural restructure (root folders, content moves, redirects) is gated behind a spike and lands in a later PR.

The docs sidebar roots will mirror the #28 Roadmap initiatives: **Andamio API · Andamio Issuer · Credential Badges · Apps & Tooling · Developer Community · Protocol**.

## What's in this PR

**Front door → documentation entry point** (`app/(home)/page.tsx`)

The `/` home page read as a marketing landing page. Reframed it as a docs index:
- **Search-forward hero** — leads with Fumadocs' `LargeSearchToggle` (the real ⌘K dialog) as the primary action; dialed-down headline; a thin "New here? Quickstart → / API Reference ↗" line. The two CTA buttons, ghost numerals, and eyebrow are gone.
- **Browse-by-section index** — a bordered six-card grid that mirrors the six-root IA, tagged with a **Product / Zone / Reference** taxonomy that matches the governance (3 products, 2 zones, Protocol reference). The bordered-grid pattern (`border-l/-t` container + `border-r/-b` cells) is count-agnostic, so it can't break when cards change.
- **No 404s** — the three not-yet-built roots (API, Apps & Tooling, Developer Community) target their best current page; they resolve to the real roots once Phase C's redirects land.

**Governance docs → six-root spine** (`.claude/skills/docs-governance/`)
- `SKILL.md`: rewrote the spine + principle; updated the gate test, `Serves` schema, placement rules, and IA mapping. Three products anchor the spine (API, Issuer, Credential Badges); Apps & Tooling, Developer Community, and Protocol are supporting zones. No single *tool* is a product-peer — the Bot lives inside Apps & Tooling.
- `phase-2-ia-restructure.md`: replaced the `ecosystem/`+`app/` target with the six-root spine and move table; **corrected the root-toggle finding** to match the verified Fumadocs 15.4.1 mechanism (tree scoping is automatic via `TreeContext`, *not* the tabs array — see decisions below); dropped the now-answered open decisions; marked Protocol contents and the Understand cluster out of scope.
- `tool-registry.md`: Bot · CLI · App Template · SDK · Andamioscan → Apps & Tooling; Repositories/Pioneers → Developer Community; `andamio-dev` stays under API.

## Key decisions

- **Tree scoping is automatic, independent of the tabs array.** Fumadocs (`fumadocs-ui` 15.4.1) scopes the sidebar in `contexts/tree.js` via `findLast(folder.root === true)` over the current path. `RootToggle`/`urls` only drive the dropdown selector + active-highlight. The real fix in the upcoming spike is `sidebar={{ tabs: true }}` (auto-derive), not a hand-call to `getSidebarTabs`. This corrects a subtly-wrong premise in the original handoff and is now recorded in the governance doc.
- **Tools move to Apps & Tooling**, superseding the old "API → Tools" placement, per the roadmap model.

## Testing

- `npx tsc --noEmit` — clean.
- Non-behavioral by nature (governance markdown + a static, CSS-only home page). No automated tests apply.
- **Verified visually** on the running dev server (light mode): search-forward hero, six-section index grid, and meta line render correctly.

## Not in this PR (gated / deferred)

- **U3 mechanism spike (hard gate)** + the full content restructure (root folders, moves, redirects, link fixes) — the spike's verification is visual (sidebar scoping in a browser), so it lands as its own PR once proven.
- **Protocol deep triage** and the **45 token/validator stubs** — separate workstreams, explicitly out of scope.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — static home-page markup plus skill/governance markdown files (not user-facing routes). Validate by loading `/` after deploy and confirming the search hero and section grid render and link correctly.

🤖 Compound-engineered with Claude Code (Opus 4.8) via `/ce-plan` → `/ce-work`.
