### PR TITLE
feat: remove paper stubs from docs, redirect to the landing

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -67,7 +67,7 @@ This is a Next.js documentation site built with Fumadocs, using content collecti
 - Transaction documentation in `content/docs/protocol/v2/transactions/`
 - Validator documentation in `content/docs/protocol/v2/validators/`
 - Token documentation in `content/docs/protocol/v2/tokens/`
-- The Andamio papers (placeholders, drafts in progress): `content/docs/light-paper.mdx`, `content/docs/andamio-issuer.mdx`, `content/docs/api/building-on-andamio.mdx`
+- The Andamio papers live on the landing (`www.andamio.io/whitepaper`), not in docs. The old docs stubs (`light-paper`, `api/building-on-andamio`) were removed and permanently redirect to the landing (see `next.config.mjs`). The `issuer` paper is now the `content/docs/issuer/` Product section. The glossary (`content/docs/glossary.mdx`) is kept as a docs-native term reference (not the paper).
 
 ### Special Features
 - Mermaid diagram support via `components/mdx/mermaid.tsx`

--- a/content/docs/api/building-on-andamio.mdx
+++ b/content/docs/api/building-on-andamio.mdx
@@ -1,8 +1,0 @@
----
-title: Building on Andamio
-description: The protocol for programmable credentials, for developers and integrators
----
-
-> **Coming soon.**
-
-For developers and integrators: the primitives, the protocol, and how to build on Andamio.

--- a/content/docs/api/meta.json
+++ b/content/docs/api/meta.json
@@ -5,7 +5,6 @@
         "index",
         "getting-started",
         "guides",
-        "reference",
-        "building-on-andamio"
+        "reference"
     ]
 }

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -21,7 +21,7 @@ There are two ways to build with Andamio, plus a live app to see it in action.
 
 ## Two products, one protocol
 
-**Andamio API** wraps the on-chain protocol into endpoints you build on. Most developers work at this level; you can also transact against the smart contracts directly. See [Building on Andamio](/docs/api/building-on-andamio).
+**Andamio API** wraps the on-chain protocol into endpoints you build on. Most developers work at this level; you can also transact against the smart contracts directly. See [Building on Andamio](https://www.andamio.io/whitepaper/building-on-andamio).
 
 **Andamio Issuer** is built on the API and abstracts the chain away entirely. It adds a verifiable credential layer to the systems an organization already runs, with no wallets or tokens for anyone to learn.
 
@@ -46,7 +46,7 @@ To see what others are building, join [Andamio Pioneers](https://discord.gg/wfGr
 ## Go deeper
 
 <Cards>
-  <Card title="Light Paper" href="/docs/light-paper">
+  <Card title="Light Paper" href="https://www.andamio.io/whitepaper">
     What Andamio is and the design decisions behind it
   </Card>
   <Card title="Glossary" href="/docs/glossary">

--- a/content/docs/light-paper.mdx
+++ b/content/docs/light-paper.mdx
@@ -1,8 +1,0 @@
----
-title: Light Paper
-description: A short read on what Andamio is, why it exists, and how credentials build trust
----
-
-> **Coming soon.** This one is being written now.
-
-A short, plain-language read on what Andamio is, why it exists, and how credentials become a signal that groups of people use to build trust.

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -11,7 +11,6 @@
         "protocol",
         "--- Reference ---",
         "glossary",
-        "light-paper",
         "--- External ---",
         "[API Reference](https://api.andamio.io)",
         "[Andamio App](https://mainnet.app.andamio.io)",

--- a/docs/plans/2026-06-29-003-feat-remove-papers-to-landing-plan.md
+++ b/docs/plans/2026-06-29-003-feat-remove-papers-to-landing-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Remove paper stubs from docs, redirect to the landing"
 type: feat
-status: active
+status: completed
 created: 2026-06-29
 origin: ../../../02-areas/andamio/docs/plans/2026-06-29-docs-remove-papers-to-landing-handoff.md
 target_repo: andamio-docs

--- a/docs/plans/2026-06-29-003-feat-remove-papers-to-landing-plan.md
+++ b/docs/plans/2026-06-29-003-feat-remove-papers-to-landing-plan.md
@@ -1,0 +1,298 @@
+---
+title: "feat: Remove paper stubs from docs, redirect to the landing"
+type: feat
+status: active
+created: 2026-06-29
+origin: ../../../02-areas/andamio/docs/plans/2026-06-29-docs-remove-papers-to-landing-handoff.md
+target_repo: andamio-docs
+---
+
+# feat: Remove paper stubs from docs, redirect to the landing
+
+## Summary
+
+The Andamio papers are front-level marketing artifacts that live on the landing
+(`www.andamio.io/whitepaper`), not in docs. Two docs pages — `light-paper.mdx` and
+`api/building-on-andamio.mdx` — are empty **"Coming soon."** placeholder stubs whose real,
+fully-written counterparts already live on the landing. This plan removes those two stubs,
+adds permanent cross-domain redirects to the canonical landing papers, repoints the in-repo
+links that pointed at them, and drops their navigation entries.
+
+The glossary is deliberately **kept** in docs. Per the execution-time decision (handoff's
+"one judgment call"), `content/docs/glossary.mdx` is a substantive 140-line developer term
+reference — not an empty stub — so it stays as a live docs-native page. Only the paper framing
+leaves; the term lookup remains.
+
+---
+
+## Problem Frame
+
+The decision is already made and locked (papers placement LOCKED 2026-06-20, re-confirmed
+2026-06-29 in the origin handoff): papers belong on the landing, docs should *reference and
+support* them, never host them. This plan is pure execution against that decision — no product
+questions remain open.
+
+What makes this safe (not content loss): the two pages being removed are placeholder stubs
+that lead with `> **Coming soon.**`. The real papers already render on the landing at
+`/whitepaper` (`light-paper` on the hub root) and `/whitepaper/building-on-andamio`. Readers
+who hit the old docs URLs land on real content instead of a placeholder — strictly an upgrade.
+
+The one risk surface is **silent breakage**: content-collections drops invalid/removed MDX
+without a build error (404s silently), and stale in-repo links won't fail the build. So the
+work must explicitly repoint every reference and verify nothing dangles.
+
+---
+
+## Requirements
+
+- **R1** — Remove the two empty paper stubs from docs: `content/docs/light-paper.mdx` and
+  `content/docs/api/building-on-andamio.mdx`.
+- **R2** — Add permanent (`permanent: true`) cross-domain redirects for each removed URL,
+  pointing at the canonical landing paper (absolute `https://www.andamio.io/...` destinations).
+- **R3** — Repoint every in-repo link that targeted a removed page to its landing destination.
+- **R4** — Remove the stubs' navigation entries from `meta.json` files without disturbing the
+  glossary entry or the Reference divider.
+- **R5** — Keep `content/docs/glossary.mdx` live and unchanged; no redirect, no nav change for it.
+- **R6** — Build green, search re-indexed with no stub pages, redirects runtime-verified, and
+  no dangling in-repo links to removed URLs.
+
+**Production domain:** `www.andamio.io` (the landing's own source uses `https://www.andamio.io`).
+**Landing slugs** (from `landing-page-and-blog/src/lib/papers.ts`): `light-paper` renders on the
+`/whitepaper` hub root; `building-on-andamio` at `/whitepaper/building-on-andamio`.
+
+---
+
+## Key Technical Decisions
+
+- **Glossary stays in docs (decision confirmed at execution).** `content/docs/glossary.mdx` is a
+  real term reference, not a stub, and is only inbound-linked from the homepage card + nav — not
+  heavily linked, but genuinely useful to developers reading docs. It remains a live docs page;
+  only the two paper stubs are removed. This means the Reference zone in `meta.json` does **not**
+  empty out (glossary remains), so the `--- Reference ---` divider **stays** — the origin's
+  "remove the divider if the zone empties" branch does not fire.
+
+- **Collapse the existing two-hop redirect chain.** `next.config.mjs` already contains
+  `{ source: '/docs/building-on-andamio', destination: '/docs/api/building-on-andamio' }`
+  (from the Phase 2 IA move). Once `/docs/api/building-on-andamio` redirects to the landing, the
+  old top-level path becomes a 2-hop chain (`/docs/building-on-andamio` → `/docs/api/building-on-andamio`
+  → landing). Repoint that existing rule directly at the landing URL so both legacy paths resolve
+  in a single hop. (see origin: handoff "Repoint in-repo links" step — extended here to redirect chains.)
+
+- **Absolute external destinations are correct and supported.** These redirects cross domains
+  (`docs.andamio.io` → `www.andamio.io`), so destinations are full absolute URLs, not in-app paths.
+  Next.js `redirects()` supports absolute URLs in `destination`; this config sets no `basePath`,
+  so no `basePath: false` flag is needed. Place the new paper redirects alongside the existing
+  array entries (order only matters for overlapping path patterns; these are exact, non-overlapping
+  sources).
+
+- **`issuer` is out of scope and correct as-is.** `content/docs/issuer/` is now a real Product
+  section (4 pages), not a paper stub — the old `andamio-issuer.mdx` already became the section
+  (an `/docs/andamio-issuer` → `/docs/issuer` redirect already exists). The CLAUDE.md reference to
+  `content/docs/andamio-issuer.mdx` as a "paper placeholder" is stale. Do not touch issuer.
+
+---
+
+## Scope Boundaries
+
+**In scope:** removing the two stub MDX pages, their redirects, their in-repo links, and their
+nav entries; collapsing the building-on-andamio redirect chain; build + runtime verification.
+
+### Deferred to Follow-Up Work
+- **Re-sync landing papers from `ee/papers` canonical** — the landing is one commit behind
+  (missing the 2026-06-24 "fence cross-issuer composability as roadmap" fix, #56). Owner-side work
+  in `landing-page-and-blog` + `scripts/sync-papers.sh`. Redirect targets are correct regardless
+  (landing already hosts the papers). (see origin: "Out of scope")
+- **Docs references + supports the papers' story (Phase 2)** — net-new doc content supporting the
+  paper narrative (e.g. fresh API "Concepts" supporting Building-on-Andamio). Separate workstream,
+  after the source of truth is solid. (see origin: "Out of scope")
+
+### Outside this change's identity
+- The glossary's content, structure, or its own internal `/docs/...` links — untouched.
+- The `issuer` Product section — untouched.
+- Any CLAUDE.md cleanup of the stale `andamio-issuer.mdx` mention — not required for this change
+  (noted for awareness only).
+
+---
+
+## Implementation Units
+
+### U1. Remove the two paper stubs and drop their nav entries
+
+**Goal:** Delete the two empty placeholder pages and remove their navigation entries, leaving the
+glossary and the Reference divider intact.
+
+**Requirements:** R1, R4, R5
+
+**Dependencies:** none
+
+**Files:**
+- Delete `content/docs/light-paper.mdx`
+- Delete `content/docs/api/building-on-andamio.mdx`
+- Modify `content/docs/meta.json` — remove the `"light-paper"` entry from the Reference zone;
+  **keep** `"glossary"` and **keep** the `"--- Reference ---"` divider (the zone is not empty).
+- Modify `content/docs/api/meta.json` — remove the `"building-on-andamio"` entry from `pages`.
+
+**Approach:** Straight deletion plus targeted JSON array edits. The root `meta.json` Reference
+zone currently lists `glossary` then `light-paper` between the `--- Reference ---` and
+`--- External ---` dividers; remove only `light-paper`. Do not touch the divider strings or the
+glossary entry. In `api/meta.json`, remove only the trailing `building-on-andamio` page.
+
+**Patterns to follow:** existing `meta.json` array-of-strings nav format already in both files.
+
+**Test scenarios:**
+- After deletion + regen, `grep 'light-paper' .content-collections/generated/allDocs.js` returns
+  nothing (page gone from the generated bundle).
+- After deletion + regen, `grep 'building-on-andamio' .content-collections/generated/allDocs.js`
+  returns nothing.
+- `grep 'glossary' .content-collections/generated/allDocs.js` still returns the glossary doc
+  (kept page survives).
+- Root `meta.json` still contains both `"--- Reference ---"` and `"glossary"` (divider + glossary
+  preserved); no longer contains `"light-paper"`.
+- `api/meta.json` `pages` no longer contains `"building-on-andamio"`.
+
+**Verification:** `npm run build` succeeds; the docs sidebar Reference section renders with the
+Glossary entry present and no Light Paper entry; the API section has no Building-on-Andamio entry.
+
+---
+
+### U2. Add cross-domain redirects in next.config.mjs
+
+**Goal:** Permanently redirect the two removed docs URLs to their canonical landing papers, and
+collapse the pre-existing building-on-andamio redirect chain to a single hop.
+
+**Requirements:** R2
+
+**Dependencies:** U1 (pages must be gone so the redirect, not the page, serves the URL)
+
+**Files:**
+- Modify `next.config.mjs` — inside the existing `redirects()` array.
+
+**Approach:** Add two new entries with absolute destinations and `permanent: true`:
+- `/docs/light-paper` → `https://www.andamio.io/whitepaper`
+- `/docs/api/building-on-andamio` → `https://www.andamio.io/whitepaper/building-on-andamio`
+
+Then update the **existing** entry (currently
+`{ source: '/docs/building-on-andamio', destination: '/docs/api/building-on-andamio', permanent: true }`)
+to point directly at `https://www.andamio.io/whitepaper/building-on-andamio`, eliminating the
+2-hop chain. Group the two new paper redirects under a short comment (e.g. "Papers live on the
+landing — old docs stubs redirect to the canonical whitepaper pages"). Sources are exact paths and
+do not overlap existing wildcard rules, so array position is not load-bearing.
+
+**Patterns to follow:** the existing redirect entries in `next.config.mjs:18-112` — same object
+shape `{ source, destination, permanent: true }`.
+
+**Test scenarios:**
+- `next.config.mjs` `redirects()` returns an entry mapping `/docs/light-paper` →
+  `https://www.andamio.io/whitepaper` with `permanent: true`.
+- `next.config.mjs` returns an entry mapping `/docs/api/building-on-andamio` →
+  `https://www.andamio.io/whitepaper/building-on-andamio` with `permanent: true`.
+- The pre-existing `/docs/building-on-andamio` entry now points directly at the landing URL (no
+  longer at the in-app `/docs/api/building-on-andamio` path) — no 2-hop chain remains.
+- Config still parses: `npm run build` completes without a config error.
+
+**Verification:** With a production build/served instance, requesting `/docs/light-paper`,
+`/docs/api/building-on-andamio`, and `/docs/building-on-andamio` each returns a 308/permanent
+redirect to the correct absolute landing URL in a single hop.
+
+---
+
+### U3. Repoint in-repo links on the homepage
+
+**Goal:** Update the homepage references that pointed at the removed pages so readers (and the
+in-app router) go to the landing papers instead of dead docs paths.
+
+**Requirements:** R3
+
+**Dependencies:** U2 (destinations should exist as redirects; links point at final landing URLs)
+
+**Files:**
+- Modify `content/docs/index.mdx`
+
+**Approach:** Three edits in `content/docs/index.mdx`:
+- Line ~24 — the prose link `[Building on Andamio](/docs/api/building-on-andamio)` → point its
+  href at `https://www.andamio.io/whitepaper/building-on-andamio`.
+- Line ~49 — the `<Card title="Light Paper" href="/docs/light-paper">` → point href at
+  `https://www.andamio.io/whitepaper`.
+- Line ~52 — the `<Card title="Glossary" href="/docs/glossary">` — **leave unchanged** (glossary
+  stays in docs).
+
+Use direct, targeted edits (not `replace_all`) to avoid touching the glossary card or unrelated
+content.
+
+**Patterns to follow:** existing Fumadocs `<Card href=...>` and markdown link usage already in
+`index.mdx`. External absolute URLs are already used elsewhere in the nav (e.g. the meta.json
+External zone links to `https://api.andamio.io`).
+
+**Test scenarios:**
+- `grep -n '/docs/light-paper' content/docs/index.mdx` returns nothing (light-paper link gone).
+- `grep -n '/docs/api/building-on-andamio' content/docs/index.mdx` returns nothing.
+- The Light Paper card and Building-on-Andamio prose link now contain the absolute
+  `https://www.andamio.io/whitepaper...` URLs.
+- `grep -n '/docs/glossary' content/docs/index.mdx` still returns the Glossary card (unchanged).
+
+**Verification:** Homepage renders; the Light Paper card and Building-on-Andamio link navigate to
+the landing; the Glossary card still navigates to the in-docs `/docs/glossary` page.
+
+---
+
+### U4. Verify build, regen, search, and redirects end-to-end
+
+**Goal:** Prove the change is clean — no dangling links, no orphaned generated entries, search
+re-indexed without the stubs, and redirects resolve at runtime.
+
+**Requirements:** R6
+
+**Dependencies:** U1, U2, U3
+
+**Files:** none (verification only)
+
+**Approach:** Run the production build and a site-wide sweep for any remaining references to the
+removed URLs across `content/`, `app/`, `components/`, `lib/`. Confirm the generated
+content-collections bundle no longer contains the stub slugs. Spot-check the served redirects.
+
+**Test scenarios:**
+- `Test expectation: none -- verification-only unit, no behavioral code added.`
+- `npm run build` exits 0.
+- Site-wide `grep` for `/docs/light-paper` and `/docs/api/building-on-andamio` across
+  `content/ app/ components/ lib/` returns no matches (the in-repo refs are gone; the only
+  remaining mentions are the redirect `source` strings in `next.config.mjs`, which are expected).
+- `.content-collections/generated/allDocs.js` contains neither stub slug and still contains
+  `glossary`.
+- Served instance: `/docs/light-paper`, `/docs/api/building-on-andamio`, and
+  `/docs/building-on-andamio` each redirect (single hop) to the correct landing URL.
+- Search index (rebuilt on build) returns no result for the removed paper stubs.
+
+**Verification:** Build green; grep sweep clean; all three redirects land on the right absolute
+landing URL; glossary page still resolves at `/docs/glossary`.
+
+---
+
+## Risks & Dependencies
+
+- **Stale-link silent breakage** — content-collections 404s silently and the build won't flag
+  stale in-repo links. Mitigated by U3's targeted repoint plus U4's site-wide grep sweep as a
+  hard gate.
+- **Redirect chain regression** — leaving the old `/docs/building-on-andamio` rule pointing at the
+  now-removed in-app path would create a 2-hop redirect (still functional, but worse). Mitigated by
+  the U2 collapse to a direct landing destination.
+- **External dependency: landing must host the papers** — the redirect targets assume the landing
+  serves `/whitepaper` and `/whitepaper/building-on-andamio`. This is already true (verified in the
+  origin handoff grounding); the deferred re-sync does not change the URLs, only their content
+  freshness, so it does not block this change.
+- **Cross-domain redirect support** — relies on Next.js honoring absolute external `destination`
+  values; standard and already used implicitly. The `npm run build` config-parse check in U2 is the
+  guard.
+
+---
+
+## Sources & Research
+
+- Origin handoff: `../../../02-areas/andamio/docs/plans/2026-06-29-docs-remove-papers-to-landing-handoff.md`
+- Stub pages confirmed empty (`> **Coming soon.**`): `content/docs/light-paper.mdx`,
+  `content/docs/api/building-on-andamio.mdx`.
+- Existing redirects + the building-on-andamio chain: `next.config.mjs:18-112` (chain at line 37).
+- In-repo references (complete set): `content/docs/index.mdx:24,49,52`; `content/docs/meta.json`
+  (Reference zone); `content/docs/api/meta.json` (`building-on-andamio`).
+- Glossary inbound-link audit: only `content/docs/index.mdx:52` (homepage card) + nav — not heavily
+  linked, supporting the keep-in-docs decision.
+- `issuer` is a live Product section (`content/docs/issuer/` — 4 pages), not a removable stub.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,6 +20,13 @@ const config = {
       // Andamio Issuer is now its own product section; the old single page moved.
       { source: '/docs/andamio-issuer', destination: '/docs/issuer', permanent: true },
 
+      // Papers live on the landing (www.andamio.io/whitepaper), not in docs. The
+      // old docs "Coming soon" stubs were removed; redirect their URLs to the
+      // canonical whitepaper pages. Destinations are absolute (cross-domain:
+      // docs.andamio.io -> andamio.io), which Next.js supports directly.
+      { source: '/docs/light-paper', destination: 'https://www.andamio.io/whitepaper', permanent: true },
+      { source: '/docs/api/building-on-andamio', destination: 'https://www.andamio.io/whitepaper/building-on-andamio', permanent: true },
+
       // guides/ dismantled across api/ and apps-tooling/ — CLI first (it lived
       // under developers/ but belongs to Apps & Tooling), then the rest.
       { source: '/docs/guides/developers/cli/:path*', destination: '/docs/apps-tooling/cli/:path*', permanent: true },
@@ -34,7 +41,10 @@ const config = {
 
       // Top-level pages moved under api/.
       { source: '/docs/getting-started', destination: '/docs/api/getting-started', permanent: true },
-      { source: '/docs/building-on-andamio', destination: '/docs/api/building-on-andamio', permanent: true },
+      // building-on-andamio is now a landing paper, not a docs page — point the
+      // legacy top-level path straight at the landing (avoids a 2-hop chain
+      // through the removed /docs/api/building-on-andamio stub).
+      { source: '/docs/building-on-andamio', destination: 'https://www.andamio.io/whitepaper/building-on-andamio', permanent: true },
       { source: '/docs/reference/:path*', destination: '/docs/api/reference/:path*', permanent: true },
 
       // Apps & Tooling.


### PR DESCRIPTION
## Summary

Readers who clicked **Light Paper** or **Building on Andamio** in the docs hit an empty "Coming soon." placeholder — even though the real, fully-written papers already live on the landing at `www.andamio.io/whitepaper`. Those two docs pages were stubs that never carried content. They're now removed, and their URLs permanently redirect to the canonical landing papers, so the same links land on real content instead of a dead placeholder.

The papers are front-level marketing artifacts; docs should reference and support them, not host them. This executes that decision for the two empty stubs.

## What changed

- **Removed** the two stub pages (`content/docs/light-paper.mdx`, `content/docs/api/building-on-andamio.mdx`) and dropped their nav entries.
- **Added** permanent (308) cross-domain redirects to the landing papers, and collapsed the pre-existing `/docs/building-on-andamio` → `/docs/api/building-on-andamio` rule to point straight at the landing (it would otherwise have become a two-hop chain through the now-removed stub).
- **Repointed** the homepage Light Paper card and Building-on-Andamio link at the landing.

| Old docs URL | Redirects to (single 308 hop) |
|---|---|
| `/docs/light-paper` | `https://www.andamio.io/whitepaper` |
| `/docs/api/building-on-andamio` | `https://www.andamio.io/whitepaper/building-on-andamio` |
| `/docs/building-on-andamio` (legacy) | `https://www.andamio.io/whitepaper/building-on-andamio` |

## Key decisions

- **The glossary stays in docs.** Unlike the two empty stubs, `content/docs/glossary.mdx` is a substantive 140-line developer term reference, so it remains a live docs-native page — only its paper framing moves to the landing. Because the glossary stays, the Reference nav divider stays too.
- **`issuer` is untouched** — it's now a real Product section (`content/docs/issuer/`), not a paper stub.
- A stale `.claude/CLAUDE.md` content-organization line still named the two deleted files; it now points at the landing (caught in code review).

## Testing

- `npm run build` green (89 static pages).
- Grep sweep across `content/ app/ components/ lib/` confirms no stale in-repo references to the removed pages remain — only the `next.config.mjs` redirect source strings.
- The generated content-collections bundle (`allDocs.js`) drops both stubs and keeps the glossary.
- No unit-test suite applies (pure content/redirect-config change).

## Post-Deploy Monitoring & Validation

After deploy, request `/docs/light-paper`, `/docs/api/building-on-andamio`, and `/docs/building-on-andamio` — each should return a **single-hop 308** to the correct `www.andamio.io/whitepaper…` URL. Confirm `/docs/glossary` still resolves (kept).

- **Healthy signal:** single 308 hop landing on a live whitepaper page.
- **Failure signal:** a redirect landing on a 404 — would indicate the landing path changed. **Mitigation:** update the redirect destination in `next.config.mjs`.

## Known Residuals

Accepted from a high-effort code review: the permanent cross-domain redirect/link destinations can't be verified from this repo. If the landing ever stops serving those `/whitepaper` paths, the cached 308s would point at a dead destination — covered by the post-deploy validation above (the landing already hosts the papers per the originating handoff). Two other review findings — the Light Paper card pointing at the `/whitepaper` hub root, and the landing URL appearing in both links and redirects — were reviewed and intentionally kept per the source-of-truth slug mapping and the deliberate link-repointing decision.

## Out of scope (tracked separately)

- Re-syncing the landing papers from the `ee/papers` canonical (landing is one commit behind; redirect targets are correct regardless).
- Net-new docs content that supports the paper narrative (Phase 2).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
