### PR TITLE
docs(credential-badges): mainnet + on-demand truth; add Resolve & Display page

### DIFF
--- a/components/credential-badges/anatomy-layers.ts
+++ b/components/credential-badges/anatomy-layers.ts
@@ -52,7 +52,13 @@ export const LAYERS: Layer[] = [
       "It's a normal image file — postable on social media, droppable into a portfolio, " +
       "embeddable anywhere — and it renders standalone, with no call back to Andamio.",
     claims: [
-      { text: "62 badges are served today (HTTP 200, image/svg+xml).", label: "live" },
+      {
+        text:
+          "Any credential serves on demand at credentials.andamio.io/badges/<policy_id>.<slt_hash>.svg " +
+          "(HTTP 200, image/svg+xml). Serving is static-first, with an on-demand render fallback, so " +
+          "a badge resolves even if it was never pre-generated.",
+        label: "live",
+      },
       {
         text:
           "The (policy_id, slt_hash) pair is decodable straight from the pixels, and a badge " +
@@ -159,15 +165,15 @@ export const LAYERS: Layer[] = [
       {
         text:
           "The on-chain course and target identity (the policy_id / slt_hash the badges are built " +
-          "from) is real on preprod, and badges provably round-trip to those hashes; anchored via " +
-          "deployed protocol validators.",
+          "from) is real on Cardano mainnet, and badges provably round-trip to those hashes; " +
+          "anchored via deployed protocol validators.",
         label: "live",
       },
       {
         text:
           "A recipient's evidence_hash is anchored on-chain and retrievable through the " +
-          "authenticated Andamio CLI, but minting a real end-to-end recipient credential_claim on " +
-          "preprod is still in flight.",
+          "authenticated Andamio CLI; exercising a full end-to-end recipient credential_claim flow " +
+          "is still in progress.",
         label: "in-dev",
       },
       {

--- a/content/docs/credential-badges/index.mdx
+++ b/content/docs/credential-badges/index.mdx
@@ -26,8 +26,8 @@ written for the **technical integrator, not the buyer** — credibility, not a s
   - **In dev** — the data or mechanism exists, but a surface around it is still being built.
   - **Coming** — designed and specified, not yet implemented.
 
-  Today's live system runs on **Cardano preprod** (the *Andamio for Developers* course is the
-  first target). Nothing undelivered is described as if it shipped.
+  Today's live system runs on **Cardano mainnet**. Credential badges (v1.0) render and serve on
+  demand for any credential. Nothing undelivered is described as if it shipped.
 </Callout>
 
 </div>

--- a/content/docs/credential-badges/meta.json
+++ b/content/docs/credential-badges/meta.json
@@ -2,6 +2,7 @@
     "title": "Credential Badges",
     "icon": "Award",
     "pages": [
-        "index"
+        "index",
+        "resolve-and-display"
     ]
 }

--- a/content/docs/credential-badges/resolve-and-display.mdx
+++ b/content/docs/credential-badges/resolve-and-display.mdx
@@ -1,0 +1,81 @@
+---
+title: Resolve & Display a Badge
+description: The URL contract for credential badges, how a badge resolves (static-first with an on-demand render fallback), and how to display one in your app.
+---
+
+A credential badge is a self-contained SVG served at a predictable, public URL.
+Displaying one is as simple as pointing an `<img>` at it. This page is the
+integrator's contract: the URL shape, how resolution works, and the few edge
+cases worth handling.
+
+<Callout type="info" title="Live on mainnet (v1.0)">
+  Badge serving is live on Cardano **mainnet**. Any credential resolves on demand,
+  so a badge does not have to be pre-generated.
+</Callout>
+
+## The URL
+
+```
+https://credentials.andamio.io/badges/<policy_id>.<slt_hash>.svg
+```
+
+- **`policy_id`**: the course's on-chain minting policy id (56 hex chars). In
+  Andamio a course is identified by its course-NFT policy, and that policy id is
+  the badge key.
+- **`slt_hash`**: the hash of the Student Learning Target the credential attests.
+
+Both values come from the credential's on-chain anchor. If you already render a
+learner's credentials, you already have them.
+
+## How it resolves
+
+Serving is **static-first with an on-demand render fallback**, so every valid
+credential resolves whether or not its badge was pre-built:
+
+1. **Hit.** If the badge is in the pre-generated set, it's served straight from
+   disk.
+2. **Miss.** The request falls through to a render service, which reads the
+   course and module titles from the Andamio gateway, renders the SVG, and
+   caches it. The first request for a new credential renders on demand, and
+   repeats serve from cache.
+
+You don't need to know which path served you. The response is the same
+`image/svg+xml` either way.
+
+## Display it
+
+It's a normal image. The SVG is self-contained (fonts embedded), so it renders
+standalone with no call back to Andamio and no client library:
+
+```html
+<img
+  src="https://credentials.andamio.io/badges/<policy_id>.<slt_hash>.svg"
+  alt="Credential badge"
+  width="180"
+  height="180"
+/>
+```
+
+### Handle a miss gracefully
+
+If a value is wrong or a badge can't be produced, the host serves a neutral
+placeholder at `…/badges/_placeholder.svg`. Point your `onError` there so a bad
+lookup degrades to a placeholder instead of a broken image:
+
+```jsx
+<img
+  src={`https://credentials.andamio.io/badges/${policyId}.${sltHash}.svg`}
+  onError={(e) => { e.currentTarget.src = "https://credentials.andamio.io/badges/_placeholder.svg"; }}
+  alt="Credential badge"
+/>
+```
+
+## Good to know
+
+- **The image is presentation-layer, never identity.** A credential's identity
+  is its on-chain anchor, and the badge is a pointer to it. An issuer may refresh
+  badge art without invalidating any issued credential, so the image is cached
+  but not immutable. See [Anatomy of a Credential Badge](/docs/credential-badges)
+  for what's actually inside.
+- **Independent verification (signing, `did:web`, baking) is v1.1.** Today a
+  badge's proof is its Proof-Ring encoding plus the on-chain anchor.


### PR DESCRIPTION
Brings the Credential Badges docs in line with the shipped **v1.0 (mainnet core)** state, and adds an integrator page for displaying badges.

## Changes
- **Staleness (preprod → mainnet):**
  - `index.mdx` current-state callout now says Cardano **mainnet** (v1.0, on-demand for any credential).
  - `anatomy-layers.ts`: the on-chain anchor "live" claim says mainnet; the recipient-`credential_claim` line drops the stale "on preprod … in flight" framing.
- **Under-claim fixed:** the serving claim was "62 badges are served today"; it now reads "any credential serves on demand" (static-first with an on-demand render fallback), matching what went live.
- **Left intentionally:** signing / `did:web` / OB 3.0 baking claims stay labeled `coming` — those are genuinely v1.1.
- **New page — `Resolve & Display a Badge`** (added to `meta.json` nav): the URL contract (`<policy_id>.<slt_hash>.svg`), hit/miss resolution, an `<img>` + `onError` placeholder example, and the presentation-layer-not-identity caveat.

Docs/content only.