### PR TITLE
Sidebar: rename Products to Get Started, drop redundant Andamio prefix

### DIFF
--- a/content/docs/api/meta.json
+++ b/content/docs/api/meta.json
@@ -1,5 +1,5 @@
 {
-    "title": "Andamio API",
+    "title": "API",
     "icon": "Code",
     "pages": [
         "index",

--- a/content/docs/issuer/meta.json
+++ b/content/docs/issuer/meta.json
@@ -1,5 +1,5 @@
 {
-    "title": "Andamio Issuer",
+    "title": "Issuer",
     "icon": "BadgeCheck",
     "pages": [
         "index",

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -1,7 +1,7 @@
 {
     "pages": [
         "index",
-        "--- Products ---",
+        "--- Get Started ---",
         "api",
         "issuer",
         "--- Explore & build ---",


### PR DESCRIPTION
## What

Two tweaks to the top sidebar section, both from the 2026-06-29 docs review:

- Section heading **Products → Get Started**
- Item labels **Andamio API → API**, **Andamio Issuer → Issuer**

## Why

- The team wasn't sure "Products" was the right grouping label for `api · issuer` (and the two weren't parallel categories anyway: one a technology, one a role). "Get Started" frames the section as the entry points where a developer begins.
- Inside Andamio's own docs, everything is Andamio, so the "Andamio" prefix on `Andamio API` / `Andamio Issuer` was pure repetition. Dropped it on the two internal items.

## Scope

Sidebar labels only (folder `meta.json` titles). Page H1s and frontmatter are untouched. External links (`Andamio App`, `andamio.io`) keep their names since they point off-site.

## Not in this PR (flagged for the review)

- `Reference → Andamio Glossary` has the same redundancy; left as-is pending the team's call.
- The docs **home page** cards and prose still say `Andamio API` / `Andamio Issuer` — a deeper content edit, separate from the nav.