### PR TITLE
Drop Andamio prefix from Glossary + home-page product cards

### DIFF
--- a/content/docs/glossary.mdx
+++ b/content/docs/glossary.mdx
@@ -1,5 +1,5 @@
 ---
-title: Andamio Glossary
+title: Glossary
 description: A reference guide for key terms, concepts, and acronyms used throughout Andamio documentation.
 ---
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -8,10 +8,10 @@ Andamio is a credentialing solution: a way for groups of people to issue, earn, 
 There are two ways to build with Andamio, plus a live app to see it in action.
 
 <Cards>
-  <Card title="Andamio API" href="/docs/api/getting-started">
+  <Card title="API" href="/docs/api/getting-started">
     The developer product. Read, mint, and gate credentials in your own app or system.
   </Card>
-  <Card title="Andamio Issuer" href="/docs/issuer">
+  <Card title="Issuer" href="/docs/issuer">
     Low-code credentialing for organizations. Add verifiable credentials to programs you already run, with no wallets or tokens to manage.
   </Card>
   <Card title="Explore the app" href="https://app.andamio.io">


### PR DESCRIPTION
## What

Continues the redundancy pass from the 2026-06-29 docs review (follows merged #50):

- **Sidebar/page:** `Andamio Glossary` → `Glossary` (glossary.mdx frontmatter title — drives both the `Reference` sidebar label and the page H1)
- **Home page cards:** `Andamio API` → `API`, `Andamio Issuer` → `Issuer`, so they match the `Get Started` sidebar items

## Why

Inside Andamio's own docs everything is Andamio; the repeated prefix was noise. #50 fixed the sidebar items; this brings the Glossary label and the home cards in line.

Verified live: sidebar reads `Reference → Glossary`, home cards read `API · Issuer · Explore the app`.

## Still untouched (judgment call, flagged for the review)

The **"Two products, one protocol"** prose on the home page still bolds **Andamio API** / **Andamio Issuer** at the point where it defines them. Naming them in full once, where they're introduced, is defensible, so I left it. Easy to trim if the team prefers.