### PR TITLE
feat(search): tune Orama docs search — typo tolerance + section scoping

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,4 +1,31 @@
 import { source } from '@/lib/source';
 import { createFromSource } from 'fumadocs-core/search/server';
 
-export const { GET } = createFromSource(source);
+// Search tuning — fumadocs-core 15.4.1, verified against the installed types.
+//
+// `search.tolerance: 1` adds Levenshtein-distance-1 fuzziness so single-char
+// typos and partial words ("treasry", "validador") still match. Conservative on
+// purpose: the team's complaint is misses, not noise — only bump to 2 if real
+// queries still fail. `threshold` is left at its Orama default (0).
+//
+// `buildIndex` mirrors the default index fields (title / description /
+// structuredData) and adds a section `tag` keyed on the root slug, which powers
+// the scoped tag filter in the ⌘K dialog (see app/layout.tsx). The home doc
+// (index.mdx) has empty slugs, so it falls back to 'home' to avoid an undefined
+// tag in the index.
+export const { GET } = createFromSource(source, {
+  language: 'english',
+  search: {
+    tolerance: 1,
+  },
+  buildIndex(page) {
+    return {
+      id: page.url,
+      title: page.data.title,
+      description: page.data.description,
+      structuredData: page.data.structuredData,
+      url: page.url,
+      tag: page.slugs[0] ?? 'home',
+    };
+  },
+});

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -8,21 +8,30 @@ import { createFromSource } from 'fumadocs-core/search/server';
 // purpose: the team's complaint is misses, not noise — only bump to 2 if real
 // queries still fail. `threshold` is left at its Orama default (0).
 //
-// `buildIndex` mirrors the default index fields (title / description /
-// structuredData) and adds a section `tag` keyed on the root slug, which powers
-// the scoped tag filter in the ⌘K dialog (see app/layout.tsx). The home doc
-// (index.mdx) has empty slugs, so it falls back to 'home' to avoid an undefined
-// tag in the index.
+// `buildIndex` reproduces fumadocs' default `pageToIndex` exactly — the
+// missing-structuredData guard and the `title ?? file.name` fallback — and adds
+// a section `tag` keyed on the root slug, which powers the scoped tag filter in
+// the ⌘K dialog (see app/layout.tsx). Keeping the default's guard/fallback means
+// a malformed or non-standard page still fails loudly (rather than silently
+// indexing `undefined`) once we override the builder. The home doc (index.mdx)
+// has empty slugs, so its tag falls back to 'home' to avoid an undefined tag.
 export const { GET } = createFromSource(source, {
   language: 'english',
   search: {
     tolerance: 1,
   },
   buildIndex(page) {
+    if (!('structuredData' in page.data)) {
+      throw new Error(
+        'Cannot find structured data from page, please define the page to index function.',
+      );
+    }
+
     return {
       id: page.url,
-      title: page.data.title,
-      description: page.data.description,
+      title: page.data.title ?? page.file.name,
+      description:
+        'description' in page.data ? page.data.description : undefined,
       structuredData: page.data.structuredData,
       url: page.url,
       tag: page.slugs[0] ?? 'home',

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,6 +21,20 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ['latin'],
 });
 
+// Curated section toggles for the ⌘K search dialog. Each `value` is a root slug
+// emitted as the index `tag` in app/api/search/route.ts. Kept to the five
+// sections people actually scope to — the other roots (developer-community,
+// contract-verification, security-audit, glossary) stay fully searchable with
+// no tag selected, just off the toggle bar to keep it uncluttered. No default
+// tag (search-everything by default); allowClear lets a chosen scope be reset.
+const searchTags = [
+  { name: 'API', value: 'api' },
+  { name: 'Issuer', value: 'issuer' },
+  { name: 'Apps & Tooling', value: 'apps-tooling' },
+  { name: 'Protocol', value: 'protocol' },
+  { name: 'Credential Badges', value: 'credential-badges' },
+];
+
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html
@@ -29,7 +43,11 @@ export default function Layout({ children }: { children: ReactNode }) {
       suppressHydrationWarning
     >
       <body className="flex flex-col min-h-screen">
-        <RootProvider>{children}</RootProvider>
+        <RootProvider
+          search={{ options: { tags: searchTags, allowClear: true } }}
+        >
+          {children}
+        </RootProvider>
       </body>
     </html>
   );

--- a/docs/plans/2026-06-30-001-feat-tune-orama-docs-search-plan.md
+++ b/docs/plans/2026-06-30-001-feat-tune-orama-docs-search-plan.md
@@ -1,0 +1,227 @@
+---
+title: "feat: Tune the built-in Orama docs search (typo tolerance + section tag scoping)"
+status: completed
+date: 2026-06-30
+type: feat
+depth: standard
+origin: ../../../02-areas/andamio/docs/plans/2026-06-30-andamio-docs-handoff-orama-search-tuning.md
+target_repo: andamio-docs
+---
+
+# feat: Tune the built-in Orama docs search (typo tolerance + section tag scoping)
+
+## Summary
+
+Docs search is 100% stock fumadocs with zero tuning, which the 2026-06-29 team review flagged as weak — people don't reliably find the right page. This plan applies the two native Orama levers that close most of the gap, at $0 / always-fresh / no new dependency:
+
+1. **Typo & partial-word tolerance** so "treasry" / "validador" return the right page.
+2. **Section tagging + a curated tag filter** in the ⌘K dialog so a query can be scoped to API / Issuer / Apps & Tooling / Protocol / Credential Badges instead of competing against every sidebar root.
+
+Acronym/synonym findability (e.g. "SLT" → "Student Learning Target") is a deliberate lighter follow-on and stays out of scope here (see Scope Boundaries). Algolia DocSearch is a deliberate *later* adoption decision, not part of this work (see origin).
+
+All work lands in two files — `app/api/search/route.ts` (index) and `app/layout.tsx` (dialog) — plus a manual QA + team-review screenshot deliverable.
+
+---
+
+## Problem Frame
+
+Search today is a plain token-match Orama index built by `createFromSource(source)` with no options. For a jargon-heavy protocol-docs site this produces three structural gaps (origin "Why"):
+
+- **No typo / partial-word tolerance** — Orama defaults to exact token match after stemming, so a single-character typo or partial word returns nothing.
+- **No scoping** — every query searches all sidebar roots flat, so the right page competes with noise from unrelated sections.
+- **No synonym / acronym mapping** — a literal token must be on the page for it to match.
+
+This plan fixes the first two (the structural wins). The third is content-level and deferred.
+
+The cause is structural (zero tuning), not a bug, so the fix is configuration of the existing engine — no engine swap, no external service.
+
+---
+
+## What's verified in the repo (2026-06-30)
+
+Research confirmed the origin's claims **and** resolved its main open uncertainty (the exact option nesting), which had shifted across fumadocs minors. Verified against the installed packages, not docs:
+
+- `fumadocs-core` and `fumadocs-ui` are both **`15.4.1`** (installed, confirmed in `node_modules`).
+- `app/api/search/route.ts` is the one-line stock index: `export const { GET } = createFromSource(source);`. Next **server mode** (no static export), so the dynamic route handler is the index source.
+- `app/layout.tsx` wraps the app in `<RootProvider>` with **no `search` prop** — stock ⌘K dialog, no tag bar.
+- `content/docs/index.mdx` exists at the docs root; its `page.slugs` is empty (no root segment) — so a tag derived from `page.slugs[0]` is `undefined` for the home page and must be defaulted.
+- Sidebar roots (from `content/docs/meta.json`, the natural tag set): `api`, `issuer`, `apps-tooling`, `credential-badges`, `developer-community`, `protocol`, `contract-verification`, `security-audit`, `glossary`.
+
+**API-shape correction (the load-bearing research finding).** The origin doc guessed search params "nest under the locale config." The installed `15.4.1` types show otherwise — `createFromSource(source, options)` takes `options` of type `Options<Page>` which extends `Omit<AdvancedOptions, 'indexes'>` and adds `buildIndex`. Confirmed shape:
+
+- `options.language?: string` (top-level, via `SharedOptions`)
+- `options.search?: Partial<SearchParams>` (top-level) — Orama `SearchParams` includes **`tolerance`** and **`threshold`** (verified in `@orama/orama` types; `threshold` defaults to `0`).
+- `options.buildIndex?: (page) => AdvancedIndex` — `AdvancedIndex` requires `id, title, structuredData, url`; optional `description, keywords, tag`. The `tag` field doc-comment reads *"Required if tag filter is enabled."*
+
+Client side, `<RootProvider search={{ options }}>` accepts `options: Partial<DefaultSearchDialogProps>`, whose tag-relevant fields are `tags?: TagItem[]`, `defaultTag?: string`, and `allowClear?: boolean` (default `false`). `TagItem = { name: string; value: string }`.
+
+> These verified names replace every "confirm the nesting" hedge in the origin. The implementer follows the shapes above; no version archaeology needed at implementation time.
+
+---
+
+## Key Technical Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Engine | Keep native Orama; tune via options | $0, always-fresh, no infra/dependency; gets most of the gap for this corpus size. Algolia is a separate later decision (see origin). |
+| Tolerance | `tolerance: 1` | Levenshtein distance 1 catches the common single-char typo / partial word. The team's complaint is **misses, not noise** — start conservative; only try `2` if real queries still fail. |
+| Threshold | Leave at default (`0`) | Lower it only if partial-term pages should surface more aggressively. Tune by feel against real queries, not preemptively. |
+| Tag source | `page.slugs[0]`, defaulted to `'home'` for the root page | The root slug is the natural section. `index.mdx` has empty slugs, so it needs an explicit fallback to avoid an `undefined` tag (origin gotcha). |
+| Visible tag set | Curate to 5 (API, Issuer, Apps & Tooling, Protocol, Credential Badges); leave the rest indexed-but-unbarred | A 9-toggle bar is clutter. These five are the sections people actually scope to. `developer-community`, `contract-verification`, `security-audit`, `glossary` stay fully searchable with no tag selected. (origin "Tag UX nuance") |
+| Default scope | No default tag (`allowClear: true`) | Search-everything by default; the user opts into a scope. Matches origin intent. |
+
+---
+
+## High-Level Technical Design
+
+Two coordinated edits across the index/dialog seam. The `tag` field is the contract between them — the server must emit it for the client filter to function.
+
+```mermaid
+flowchart LR
+  subgraph server["app/api/search/route.ts (U1)"]
+    A["createFromSource(source, options)"]
+    A --> B["search: { tolerance: 1 }"]
+    A --> C["buildIndex(page) →<br/>{ id, title, description,<br/>structuredData, url,<br/>tag: slugs[0] ?? 'home' }"]
+  end
+  subgraph client["app/layout.tsx (U2)"]
+    D["RootProvider search={{ options }}"]
+    D --> E["tags: 5 curated TagItems"]
+    D --> F["allowClear: true"]
+  end
+  C -. "tag value powers" .-> E
+  B -. "fuzzier matching at" .-> G(["/api/search"])
+  E -. "?tag= passed to" .-> G
+```
+
+The `tag` emitted by `buildIndex` (U1) is what the dialog's tag bar (U2) filters on. U2 is inert without U1's tag field; ship in order.
+
+---
+
+## Implementation Units
+
+### U1. Tune the server-side search index — tolerance + section tag
+
+**Goal:** Replace the stock one-line index with a tuned `createFromSource` call that adds typo tolerance and a per-page section `tag`.
+
+**Requirements:** origin "What to change" §1 (tolerance) and §2 (tag the index).
+
+**Dependencies:** none.
+
+**Files:**
+- `app/api/search/route.ts` (modify)
+
+**Approach:**
+- Pass an options object to `createFromSource(source, options)` with:
+  - `language: 'english'` (single-language site)
+  - `search: { tolerance: 1 }` — leave `threshold` unset (default `0`)
+  - `buildIndex(page)` returning `{ id: page.url, title, description, structuredData, url: page.url, tag }` where `tag = page.slugs[0] ?? 'home'`
+- Use the verified `15.4.1` shapes in "What's verified in the repo" — `search` and `buildIndex` are top-level options, not nested under locale. Follow the installed types over any older snippet if they ever diverge.
+- Keep the default index fields intact (title/description/structuredData) so nothing drops out of the index; the only additions are the tuned `search` and the `tag`.
+
+**Patterns to follow:** the existing `import { source } from '@/lib/source'` wiring; `AdvancedIndex` field names from `fumadocs-core/dist/search/server.d.ts`.
+
+**Test scenarios** (manual — no search test harness in repo; run `npm run dev` and exercise `/api/search` via the ⌘K dialog):
+- Covers origin Verification. Typo query "treasry" → returns the Treasury page (was empty before).
+- Typo query "validador" → returns the relevant validator page.
+- Partial-word query (e.g. "creden") → returns Credential Badges pages.
+- Completeness: with **no tag selected**, every root still returns its pages — confirm no section dropped out of the index after switching to explicit `buildIndex`. Spot-check one page from each of the 9 roots.
+- Home page: searching a term unique to `index.mdx` returns it with `tag: 'home'` (no `undefined`-tag crash in the index build).
+
+**Verification:** dev server builds with no type error; the five queries above behave as described; the index is complete with no tag selected.
+
+---
+
+### U2. Expose a curated section tag filter in the ⌘K dialog
+
+**Goal:** Render a curated tag toggle bar in the default search dialog so users can scope a query to a section.
+
+**Requirements:** origin "What to change" §2 (expose a tag filter), including the "Tag UX nuance — don't dump all 9 roots."
+
+**Dependencies:** U1 (the dialog filters on the `tag` field U1 emits).
+
+**Files:**
+- `app/layout.tsx` (modify)
+
+**Approach:**
+- Pass `search={{ options: { tags, allowClear: true } }}` to `<RootProvider>`, where `tags` is the curated `TagItem[]`:
+
+  | `name` (label) | `value` (slug) |
+  |---|---|
+  | API | `api` |
+  | Issuer | `issuer` |
+  | Apps & Tooling | `apps-tooling` |
+  | Protocol | `protocol` |
+  | Credential Badges | `credential-badges` |
+
+- No `defaultTag` (search-everything by default); `allowClear: true` so a selected scope can be cleared.
+- Leave `developer-community`, `contract-verification`, `security-audit`, `glossary` **off the bar but still indexed** (they remain searchable with no tag selected).
+- Use `TagItem = { name, value }` and `DefaultSearchDialogProps.tags` / `allowClear` from the verified `15.4.1` types.
+
+**Patterns to follow:** the existing `<RootProvider>{children}</RootProvider>` in `app/layout.tsx` — add the `search` prop only; leave font/theme wiring untouched.
+
+**Test scenarios** (manual, via ⌘K dialog):
+- Tag bar renders exactly the five curated toggles, none of the other four.
+- Selecting **Protocol** then querying a term that exists in both protocol and another root → results narrow to protocol pages only.
+- Clearing the tag (allowClear) → results widen back to all sections.
+- A page under an un-barred root (e.g. a `glossary` page) is still reachable with **no tag selected** but does not appear when a non-matching tag is active.
+- Tolerance still applies within a scope: typo + Protocol selected → typo-corrected protocol page returns.
+
+**Verification:** the dialog shows the five toggles, scoping narrows correctly, clearing restores full search, and un-barred sections remain searchable untagged.
+
+---
+
+### U3. Manual QA pass + team-review screenshot
+
+**Goal:** Validate the end-to-end behavior against the queries that fail today and produce the screenshot the team review asked for.
+
+**Requirements:** origin "Verification" (run the failing queries; sanity-check no section dropped; screenshot the dialog with toggles).
+
+**Dependencies:** U1, U2.
+
+**Files:** none (verification deliverable; screenshot is shared to the team channel / review, not committed unless the team wants it in-repo).
+
+**Approach:**
+- Run `npm run dev` and walk the full origin verification checklist: deliberate typos ("treasry", "validador"), a partial word, and a section-specific term with the matching tag selected.
+- Confirm no section dropped out of the index (every root returns pages with no tag selected).
+- Capture a screenshot of the dialog with the tag toggles visible for the 2026-06-29 team review follow-up.
+
+**Test expectation: none** — this is a manual QA + artifact unit, not behavior-bearing code. Its scenarios are U1's and U2's, exercised together end-to-end.
+
+**Verification:** all origin verification bullets pass; screenshot captured and shared.
+
+---
+
+## Scope Boundaries
+
+### In scope
+- Typo/partial tolerance (`tolerance: 1`) on the server index.
+- Per-page section `tag` + curated 5-tag client filter.
+- Manual QA + team-review screenshot.
+
+### Deferred to Follow-Up Work
+- **Acronym / synonym findability (origin Phase 2).** The fumadocs Orama wrapper doesn't cleanly expose Orama's synonym config, so the durable fix is content-level: write acronyms with their expansion on first use (e.g. "SLT (Student Learning Target)") and/or add a `keywords` frontmatter line on highest-traffic pages with the alt terms people type. Lighter, separate pass after this ships. Note: `keywords` is a first-class `AdvancedIndex` field in `15.4.1`, so frontmatter `keywords` could be wired into `buildIndex` later with no engine magic.
+- **Tolerance/threshold loosening.** Trying `tolerance: 2` or lowering `threshold` — only if the team still reports misses against real queries after Phase 1.
+- **"More" grouping for the un-barred roots** — only if the dialog component supports it and the team wants those four sections one click away.
+
+### Outside this work's identity
+- **Algolia DocSearch.** Free for public docs with real relevance + search analytics, but it adds an apply/approval gate, weekly-crawl freshness lag, and an external dependency. Revisit when we specifically want the search-analytics loop (which queries return nothing) or the corpus grows enough that ranking-at-scale bites. The two can coexist — this raises the baseline now; Algolia can replace it later via a custom `SearchDialog`. Decision analysis lives in the Andamio Documentation working session (orch). (origin "Out of scope")
+
+---
+
+## Risks & Gotchas
+
+- **Server mode, not static export.** The `/api/search` route handler is the index source. If the site is ever flipped to `output: 'export'`, this breaks and would need fumadocs static-search mode (`type: 'static'` + `staticGET`). Not a concern today — just don't let an export migration silently kill search.
+- **`page.slugs[0]` for the home doc is `undefined`.** Handled by the `?? 'home'` fallback in U1. Verify no other index-only or special page produces an unexpected root.
+- **Don't over-fuzz.** `tolerance: 2` + low `threshold` makes everything match everything. The complaint is misses, not noise — ship conservative, loosen only on evidence.
+- **Tag contract coupling.** U2 is inert without U1's `tag` field; ship U1 first. If the bar renders but scoping does nothing, the `tag` value in the index (U1) is the first thing to check.
+
+---
+
+## Sources & Research
+
+- **Origin handoff:** `02-areas/andamio/docs/plans/2026-06-30-andamio-docs-handoff-orama-search-tuning.md` (James's decision + the what/why/gotchas this plan executes).
+- **Installed types (verified, load-bearing — corrected the origin's nesting guess):**
+  - `node_modules/fumadocs-core/dist/search/server.d.ts` — `createFromSource` `Options<Page>`, `AdvancedOptions.search`, `AdvancedIndex` fields (`tag`, `structuredData`, `keywords`).
+  - `node_modules/@orama/orama/dist/browser/types.d.ts` — `SearchParams.tolerance` / `.threshold` (default `0`).
+  - `node_modules/fumadocs-ui/dist/provider/base.d.ts` + `components/dialog/search-default.d.ts` + `components/dialog/search.d.ts` — `RootProvider` `search.options`, `DefaultSearchDialogProps` (`tags`, `defaultTag`, `allowClear`), `TagItem = { name, value }`.
+- **Tag set source of truth:** `content/docs/meta.json` (sidebar roots).


### PR DESCRIPTION
## Summary

Docs search now tolerates typos and can be scoped to a section. Before this, the ⌘K dialog was 100% stock fumadocs with zero tuning — a plain exact-token index over every sidebar root flat — so a single mistyped character returned nothing and every query competed against the whole site. The 2026-06-29 team review flagged search as unreliable; this closes the two structural gaps with the native Orama levers, at no new dependency and no external service.

Two changes:
- **Typo / partial-word tolerance** (`search.tolerance: 1`) so partial words and common single-char typos still surface the right page.
- **Section scoping** — each page is now tagged by its root slug, and the dialog renders a curated five-section filter (API · Issuer · Apps & Tooling · Protocol · Credential Badges) so a query can be narrowed to where the answer lives.

## Key decisions

- **Native Orama, not Algolia.** Tuned Orama is $0, always-fresh, and needs no apply/approval or crawl infra. Algolia DocSearch stays a deliberate *later* decision — revisit it when we specifically want the search-analytics loop, not as part of raising the baseline now.
- **`tolerance: 1`, evidence-based.** `tolerance: 2` fixes more mid-word typos but floods short/acronym queries — `cip` jumps 29→547 results, `slt` 114→506 — which is the wrong trade for an acronym-heavy protocol site where nonsense input (`zzzznonsense`) still correctly returns nothing. Kept the conservative value; the residual mid-word misses are better closed by the deferred content-level `keywords` pass.
- **Five visible tags, not nine.** The other roots (developer-community, contract-verification, security-audit, glossary) stay fully searchable with no tag selected — just off the toggle bar to keep it uncluttered. No default scope; `allowClear` lets a chosen scope reset.
- **`buildIndex` is a faithful superset of the default.** It reproduces fumadocs' `pageToIndex` exactly — the missing-`structuredData` guard and the `title ?? file.name` fallback — and only adds the `tag`, so overriding the builder doesn't quietly drop the default's safety behaviors.

A note for the next person touching this: the installed `fumadocs-core@15.4.1` types put `search` and `buildIndex` as **top-level** options on `createFromSource(source, options)` — not nested under a locale config as older snippets suggest. `tsc` is the source of truth here.

## Testing

No automated search-test harness exists in this repo (docs-site config change); verified by type-check, lint, and live exercise of the running index:

- `tsc --noEmit` clean; `next lint` clean.
- **Tag scoping** against `/api/search` on the dev server: `token` returns 171 hits across all sections; `tag=protocol` narrows to 38 (protocol only), `tag=api` to 49 (api subtree), `tag=credential-badges` to 11. All five curated roots return their own pages, and the index stays complete with no tag selected.
- **Tolerance**: `protcol`→protocol confirms `tolerance: 1` is active; the `tolerance: 2` measurements above drove the decision to keep `1`.
- Captured a screenshot of the dialog with the five-tag toggle bar for the team-review follow-up.

## Code review

Workflow-backed `/code-review` at high effort surfaced two PLAUSIBLE findings — the custom `buildIndex` had dropped the default's `structuredData` guard and `title` fallback. Both are fixed (commit `164746d`); neither was reachable under the current content-collections schema, but the fix keeps the override honest.

## Follow-up (not in this PR)

- Acronym/synonym findability via `keywords` frontmatter on high-traffic pages — the durable fix for the residual mid-word typo misses ("SLT" → "Student Learning Target").
- Loosen `tolerance`/`threshold` only if real queries still miss after this ships.
- Algolia DocSearch when the search-analytics loop is specifically wanted.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — static docs site, no runtime or data impact; validation is the manual query checks above. One watch item: if the site is ever switched to `output: 'export'`, the `/api/search` route handler stops being the index source and search would need fumadocs static-search mode instead.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
