### PR TITLE
Make the API-key distinction explicit (developer vs enterprise)

### DIFF
--- a/content/docs/api/index.mdx
+++ b/content/docs/api/index.mdx
@@ -3,6 +3,10 @@ title: Andamio API
 description: The developer product — build on the protocol from your own stack.
 ---
 
+<Callout type="info" title="This is the developer-key path">
+  These docs cover the Andamio **API**, which uses a **developer key**: you build on `/api/v2`, fund your own transactions, and your users act on their own behalf. Hold an **enterprise key** instead (Andamio sponsors your transactions)? See the [Issuer](/docs/issuer) docs.
+</Callout>
+
 The Andamio API is the developer product: REST endpoints and guides for issuing,
 verifying, and gating on-chain credentials from your own stack.
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -27,6 +27,16 @@ There are two ways to build with Andamio, plus a live app to see it in action.
 
 The **app** at [app.andamio.io](https://app.andamio.io) is a reference implementation on the API, open to anyone who wants to explore.
 
+## Two keys, two paths
+
+Andamio API and Andamio Issuer are two products with two different API keys, and the key you hold decides which one you build against.
+
+**Andamio API** uses a developer key. You build directly on the protocol under `/api/v2`: read, mint, and gate credentials in your own app. Your users sign in and act on their own behalf, and you fund the transactions you submit.
+
+**Andamio Issuer** uses an enterprise key. You issue credentials under `/issuer/v1`, and Andamio sponsors every transaction, covering the on-chain fees. Your application is the only credential the API needs, so there are no end-user wallets or tokens to manage.
+
+The two keys aren't interchangeable. A developer key calling an Issuer route, or an enterprise key calling a developer route, is rejected (HTTP 403). So follow the section that matches your key: the [API](/docs/api/getting-started) docs for a developer key, the [Issuer](/docs/issuer) docs for an enterprise key.
+
 ## What makes an Andamio credential different
 
 **Persistent.** Immutable and stored on public infrastructure no single company owns. A credential outlives whoever issued it.

--- a/content/docs/issuer/index.mdx
+++ b/content/docs/issuer/index.mdx
@@ -3,6 +3,10 @@ title: Andamio Issuer
 description: Low-code, verifiable credentials for the systems you already run
 ---
 
+<Callout type="info" title="This is the enterprise-key path">
+  These docs cover the Andamio **Issuer**, which uses an **enterprise key**: Andamio sponsors every transaction and your application is the only credential the API needs. Hold a **developer key** instead (you build on `/api/v2` and fund your own transactions)? See the [API](/docs/api/getting-started) docs.
+</Callout>
+
 <Callout type="info">
   Andamio Issuer is in active development. This section is a scaffold: the shape is settling, and detailed guides will land as the product firms up.
 </Callout>


### PR DESCRIPTION
## What

From the 2026-06-29 docs review: make explicit that **Andamio API** and **Andamio Issuer** use **different API keys**, and the key you hold determines which docs are useful to you.

- **Home page** — new `## Two keys, two paths` section: developer key builds on `/api/v2` and funds its own transactions; enterprise key issues on `/issuer/v1` with Andamio sponsoring every transaction; the two keys aren't interchangeable.
- **API landing** (`api/index.mdx`) — a "developer-key path" callout that cross-links to Issuer.
- **Issuer landing** (`issuer/index.mdx`) — an "enterprise-key path" callout that cross-links to API (sits above the existing "in active development" note).

## Grounding (live v2.5 work in andamio-api)

This isn't a conceptual framing, it mirrors what v2.5 actually enforces:

- API-key `kind` is `developer` vs `enterprise`, gated by `RequireKind` middleware (`internal/middleware/require_kind.go`).
- **Developer (Path A):** `/api/v2/*`, bring-your-own `sponsor_data` (self-funded), end-user JWT carries user identity.
- **Enterprise Issuer (Path B):** `/issuer/v1/*` (separate top-level namespace), Andamio sponsors every tx, the enterprise key is the *sole* credential (no end-user bearer token). Has its own OpenAPI contract.
- Enforcement: a developer key on an Issuer route, or an enterprise key on a developer route, gets **403**; no key gets **401**. That's what makes "the key you hold determines which docs apply" literally true.

Sources: `andamio-api` `docs/ARCHITECTURE.md` §Enterprise Issuer, `internal/handlers/issuer/doc.go`, `internal/middleware/require_kind.go`.

## Honesty / status

The two-key *model* and its *enforcement* are live; the full Issuer endpoint set is still landing across v2.5 release candidates (which is why the deeper Issuer integration guide is still blocked on request/response schemas). The copy states the model without enumerating endpoints, so it stays accurate today. Verified live: all three pages render, heading check passes.

## Flagged, not changed

Both the home page and `issuer/index.mdx` still say Issuer "is built on the **API**." Post-v2.5, `/issuer/v1` is a *sibling* namespace of `/api` (it shares `/v2/tx` request structs but isn't mounted under `/api`). Left as-is pending a call on whether to soften to "built on the same protocol."