### PR TITLE
docs(api): route API-key setup through the mainnet portal

### DIFF
--- a/content/docs/api/accounts/api-integration.mdx
+++ b/content/docs/api/accounts/api-integration.mdx
@@ -77,7 +77,7 @@ All code examples in these docs use preprod URLs.
 
 When your app is tested and ready for production:
 
-1. Generate a **mainnet API key** at [app.andamio.io/api-setup](https://app.andamio.io/api-setup)
+1. Generate a **mainnet API key** at [app.andamio.io/api-setup](https://app.andamio.io/api-setup) — the same portal that manages your preprod keys
 2. Update your environment variables:
    ```bash
    NEXT_PUBLIC_ANDAMIO_GATEWAY_URL="https://mainnet.api.andamio.io"

--- a/content/docs/api/accounts/api-keys.mdx
+++ b/content/docs/api/accounts/api-keys.mdx
@@ -5,9 +5,17 @@ description: Request, rotate, and manage API keys for the Andamio Gateway
 
 Authenticated requests to the Andamio API require an API key in the `X-API-Key` header. API keys identify your application and determine your rate limits and quotas. A few public endpoints (developer registration, login, billing plans) do not require a key.
 
+## Your First Key
+
+Your first API key comes from the developer portal at [app.andamio.io/api-setup](https://app.andamio.io/api-setup) — the endpoints below all require an existing key, so the portal is the bootstrap. The portal lives on the **mainnet** app only and manages keys for every environment via its network selector; `/api-setup` on the preprod app redirects to the dashboard by design. See the [Quickstart](/docs/api/getting-started) for the full flow.
+
+<Callout type="warn" title="Preprod keys are in limited access">
+Self-serve **preprod** key generation is currently limited to internal testers. Ask in the [Andamio Discord](https://discord.gg/wfGrgJJheS) for a preprod key while access rolls out.
+</Callout>
+
 ## Prerequisites
 
-Before requesting an API key:
+Before requesting an API key via the endpoints below:
 
 1. [Register a developer account](/docs/api/accounts/developer-accounts)
 2. Verify your email address (required for key creation)

--- a/content/docs/api/getting-started.mdx
+++ b/content/docs/api/getting-started.mdx
@@ -8,27 +8,35 @@ description: From zero to your first Andamio API call in 5 minutes, then the loc
 Get from zero to a working Andamio API call, then set up the local app template when you're ready to build a frontend.
 
 <Callout title="Prerequisites">
-- **Cardano wallet on preprod with test ADA** — [Setup guide](/docs/apps-tooling/andamio-app/preprod-wallet-setup)
+- **Cardano wallet on mainnet with a small amount of ADA** — developer registration happens on the mainnet app
+- **Cardano wallet on preprod with test ADA** for development — [Setup guide](/docs/apps-tooling/andamio-app/preprod-wallet-setup)
 - For the app template (optional): **Node.js 20+** and **npm 10+**
 </Callout>
 
 ## 1. Mint your Access Token
 
-Your Access Token is your on-chain identity for Andamio.
+Your Access Token is your on-chain identity for Andamio. Developer registration lives on the **mainnet** app, so you need a mainnet Access Token — a preprod-only token can't register a developer account.
 
-1. Go to [preprod.app.andamio.io](https://preprod.app.andamio.io)
+1. Go to [app.andamio.io](https://app.andamio.io)
 2. Click **Enter** → **Connect Wallet**
-3. Connect your wallet (preprod network)
+3. Connect your wallet (mainnet network)
 4. Enter an alias (permanent)
 5. Click **Mint Access Token** and sign
 6. Wait ~20 seconds for confirmation
 
-## 2. Generate an API Key
+## 2. Register and generate an API Key
 
-1. Go to [preprod.app.andamio.io/api-setup](https://preprod.app.andamio.io/api-setup)
+API keys for **every environment** — preprod included — are managed on the mainnet app. (`/api-setup` on the preprod app redirects to the dashboard by design.)
+
+1. Go to [app.andamio.io/api-setup](https://app.andamio.io/api-setup)
 2. Connect your wallet and sign in to the Gateway
-3. Select **preprod**
-4. Click **Generate API Key** and name it (e.g., "local-dev")
+3. Register as a developer
+4. Select the network for your key — **preprod** for development
+5. Click **Generate API Key** and name it (e.g., "local-dev")
+
+<Callout type="warn" title="Preprod keys are in limited access">
+Self-serve **preprod** key generation is currently limited to internal testers (the request fails with a 403). Ask in the [Andamio Discord](https://discord.gg/wfGrgJJheS) and the team will provision a preprod key for you while self-serve access rolls out. Mainnet keys are available to all registered developers.
+</Callout>
 
 <Callout type="warn" title="Save your key">
 Copy the key immediately — it won't be shown again.
@@ -123,6 +131,8 @@ npm run dev
 
 Open [localhost:3000](http://localhost:3000), click **Enter**, connect your wallet, and you should see your dashboard with your alias.
 
+To sign in to your local app you'll need a **preprod** Access Token — mint one at [preprod.app.andamio.io](https://preprod.app.andamio.io) (same flow as step 1, with test ADA).
+
 <Callout type="success">Setup complete.</Callout>
 </Step>
 </Steps>
@@ -133,12 +143,14 @@ Open [localhost:3000](http://localhost:3000), click **Enter**, connect your wall
 
 These docs use **preprod** (Cardano testnet) for safe development. When your app is ready for production:
 
-1. Generate a mainnet API key at [app.andamio.io/api-setup](https://app.andamio.io/api-setup)
+1. Generate a mainnet API key at [app.andamio.io/api-setup](https://app.andamio.io/api-setup) — the same portal that manages your preprod keys
 2. Update `.env` with mainnet settings — see [Environment Reference](/docs/api/reference/environments)
 
 ---
 
 ## Troubleshooting
+
+**"/api-setup redirects me to /dashboard"** — You're on the preprod app. API keys are managed on the mainnet app: [app.andamio.io/api-setup](https://app.andamio.io/api-setup).
 
 **"Access Token not found"** — Check your wallet is set to preprod network.
 

--- a/content/docs/api/reference/environments.mdx
+++ b/content/docs/api/reference/environments.mdx
@@ -9,9 +9,13 @@ Start on **preprod** for development. Move to **production** when your app is te
 
 | Environment | Gateway URL | App URL | Generate API Key |
 |-------------|-------------|---------|------------------|
-| **Preprod** (start here) | `preprod.api.andamio.io` | [preprod.app.andamio.io](https://preprod.app.andamio.io) | [preprod.app.andamio.io/api-setup](https://preprod.app.andamio.io/api-setup) |
+| **Preprod** (start here) | `preprod.api.andamio.io` | [preprod.app.andamio.io](https://preprod.app.andamio.io) | [app.andamio.io/api-setup](https://app.andamio.io/api-setup) (see note) |
 | Production | `mainnet.api.andamio.io` | [app.andamio.io](https://app.andamio.io) | [app.andamio.io/api-setup](https://app.andamio.io/api-setup) |
 | Development | `dev.api.andamio.io` | [dev.app.andamio.io](https://dev.app.andamio.io) | Internal — contact team |
+
+<Callout type="warn" title="All API keys are managed on the mainnet app">
+API keys for every environment — preprod included — are generated at [app.andamio.io/api-setup](https://app.andamio.io/api-setup) using the network selector. `/api-setup` on the preprod app redirects to the dashboard by design. Registration requires a **mainnet** Access Token, and self-serve preprod key generation is currently limited to internal testers — ask in the [Andamio Discord](https://discord.gg/wfGrgJJheS) for a preprod key while access rolls out.
+</Callout>
 
 ## Access Token Policy IDs
 
@@ -46,10 +50,9 @@ NEXT_PUBLIC_ACCESS_TOKEN_POLICY_ID="<contact-team-for-mainnet-policy-id>"
 
 When your app is tested and ready:
 
-1. **Generate a mainnet API key** at [app.andamio.io/api-setup](https://app.andamio.io/api-setup)
-2. **Mint a mainnet Access Token** at [app.andamio.io](https://app.andamio.io) (requires real ADA)
-3. **Update environment variables** with production values above
-4. **Contact the Andamio team** for the mainnet Access Token policy ID
+1. **Generate a mainnet API key** at [app.andamio.io/api-setup](https://app.andamio.io/api-setup) — you already have a mainnet Access Token from developer registration
+2. **Update environment variables** with production values above
+3. **Contact the Andamio team** for the mainnet Access Token policy ID
 
 ## App Template Scripts
 


### PR DESCRIPTION
## Why

A developer bug report (2026-07-06) traced straight back to these docs: the Quickstart and Environments reference send developers to `preprod.app.andamio.io/api-setup`, which redirects to `/dashboard` by design — the dev portal is mainnet-only. Following the docs as written, a developer with a preprod-only Access Token can't generate a key and can't register on the mainnet portal either, with no explanation anywhere.

## What changed

The docs now describe the real flow: **mainnet Access Token → app.andamio.io/api-setup → register → generate key**, with the network selector minting keys for either environment.

- **Quickstart** — mainnet-first flow (prerequisites, access token, key generation), explicit "a preprod-only token can't register" warning, preprod-token note for the app template, and a troubleshooting entry for the exact redirect symptom reported
- **Environments** — Quick Reference table no longer points preprod at the preprod app; single-portal callout with the current preprod-key access status
- **API Keys** — new "Your First Key" section: every endpoint on the page requires an existing key, so the portal is the bootstrap (previously unstated)
- **API Integration** — one-line clarifier that the mainnet portal manages preprod keys too

## Follow-up

Self-serve preprod key generation is currently limited to internal testers; the callouts say so and point to Discord for interim provisioning. When GA preprod keys ship (in flight this week), those callouts get deleted.