### PR TITLE
docs(api): preprod keys open to everyone — reconcile with API v2.4.1

### DIFF
--- a/content/docs/api/accounts/api-keys.mdx
+++ b/content/docs/api/accounts/api-keys.mdx
@@ -9,8 +9,8 @@ Authenticated requests to the Andamio API require an API key in the `X-API-Key` 
 
 Your first API key comes from the developer portal at [app.andamio.io/api-setup](https://app.andamio.io/api-setup) — the endpoints below all require an existing key, so the portal is the bootstrap. The portal lives on the **mainnet** app only and manages keys for every environment via its network selector; `/api-setup` on the preprod app redirects to the dashboard by design. See the [Quickstart](/docs/api/getting-started) for the full flow.
 
-<Callout type="warn" title="Preprod keys are in limited access">
-Self-serve **preprod** key generation is currently limited to internal testers. Ask in the [Andamio Discord](https://discord.gg/wfGrgJJheS) for a preprod key while access rolls out.
+<Callout type="info" title="Preprod keys are open to everyone">
+Self-serve **preprod** key generation is open to all registered developers as of API v2.4.1 (July 2026). If you previously hit a 403 generating a preprod key, retry — the internal-testers gate has been removed.
 </Callout>
 
 ## Prerequisites

--- a/content/docs/api/getting-started.mdx
+++ b/content/docs/api/getting-started.mdx
@@ -34,8 +34,8 @@ API keys for **every environment** — preprod included — are managed on the m
 4. Select the network for your key — **preprod** for development
 5. Click **Generate API Key** and name it (e.g., "local-dev")
 
-<Callout type="warn" title="Preprod keys are in limited access">
-Self-serve **preprod** key generation is currently limited to internal testers (the request fails with a 403). Ask in the [Andamio Discord](https://discord.gg/wfGrgJJheS) and the team will provision a preprod key for you while self-serve access rolls out. Mainnet keys are available to all registered developers.
+<Callout type="info" title="Preprod keys are open to everyone">
+Preprod and mainnet key generation are both open to all registered developers — as of API v2.4.1 (July 2026), no special access is needed for preprod. If you previously hit a 403 here, retry.
 </Callout>
 
 <Callout type="warn" title="Save your key">

--- a/content/docs/api/reference/environments.mdx
+++ b/content/docs/api/reference/environments.mdx
@@ -14,7 +14,7 @@ Start on **preprod** for development. Move to **production** when your app is te
 | Development | `dev.api.andamio.io` | [dev.app.andamio.io](https://dev.app.andamio.io) | Internal — contact team |
 
 <Callout type="warn" title="All API keys are managed on the mainnet app">
-API keys for every environment — preprod included — are generated at [app.andamio.io/api-setup](https://app.andamio.io/api-setup) using the network selector. `/api-setup` on the preprod app redirects to the dashboard by design. Registration requires a **mainnet** Access Token, and self-serve preprod key generation is currently limited to internal testers — ask in the [Andamio Discord](https://discord.gg/wfGrgJJheS) for a preprod key while access rolls out.
+API keys for every environment — preprod included — are generated at [app.andamio.io/api-setup](https://app.andamio.io/api-setup) using the network selector. `/api-setup` on the preprod app redirects to the dashboard by design. Registration requires a **mainnet** Access Token. Self-serve preprod key generation is open to all registered developers (API v2.4.1).
 </Callout>
 
 ## Access Token Policy IDs


### PR DESCRIPTION
## Why

The v2.4.1 hotfix ([andamio-api#600](https://github.com/Andamio-Platform/andamio-api/pull/600), released 2026-07-06) removed the internal stake allowlist gate — self-serve **preprod** key generation is now open to all registered developers.

This morning's #59 correctly documented the internal-testers gate; the same-day patch made that caveat obsolete. This PR retires it across the three pages that carried it.

## What changed

- **API Keys** (`api-keys.mdx`): warn callout → info callout ("open to everyone as of v2.4.1; if you previously hit a 403, retry")
- **Environments** (`environments.mdx`): dropped the internal-testers sentence from the mainnet-portal callout
- **Quickstart** (`getting-started.mdx`): warn callout → info callout, same retry note

Mainnet-portal routing (keys managed on app.andamio.io, preprod redirect by design) is unchanged and still correct.

Context: an external developer (Ashu) hit the 403 + redirect yesterday — these pages are about to be shared with him, so they need to match live behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)