### PR TITLE
docs(credential-badges): how-it-works + anatomy, current to v1.1 + context v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ package-lock.json
 .env*.local
 .vercel
 next-env.d.ts
+.worktrees

--- a/components/credential-badges/anatomy-layers.ts
+++ b/components/credential-badges/anatomy-layers.ts
@@ -130,7 +130,10 @@ export const LAYERS: Layer[] = [
       "identity so a verifier can check who signed it.",
     claims: [
       {
-        text: "/context/v0.jsonld serves Andamio's OB 3.0 extension terms (versioned, immutable).",
+        text:
+          "/context/v1.jsonld serves Andamio's OB 3.0 extension terms. Published context " +
+          "versions are immutable: new vocabulary mints the next version URL, and every prior " +
+          "version (v0) keeps serving forever so already-signed credentials still verify.",
         label: "live",
       },
       {
@@ -154,7 +157,9 @@ export const LAYERS: Layer[] = [
       {
         text:
           "A hosted, human-facing verification page. Today verification is done by DI-capable " +
-          "OB 3.0 verifiers (e.g. spruce, 1EdTech) and by the self-verifying baked badge.",
+          "OB 3.0 verifiers (e.g. spruce, 1EdTech) and by the self-verifying baked badge — " +
+          "1EdTech's validator independently confirmed a signed badge 13/13, zero warnings " +
+          "(2026-07-23).",
         label: "coming",
       },
     ],

--- a/content/docs/credential-badges/how-it-works.mdx
+++ b/content/docs/credential-badges/how-it-works.mdx
@@ -14,13 +14,15 @@ not a decorative stand-in for a record kept somewhere else — its geometry enco
 the credential's on-chain identity and round-trips back to the chain. This page
 takes one apart, layer by layer, then shows how it resolves and where it's going.
 
-<Callout type="info" title="Live on Cardano mainnet (v1.0)">
+<Callout type="info" title="Live on Cardano mainnet">
   Credential badges are live in production. Any credential resolves on demand at
   `https://credentials.andamio.io/badges/<policy_id>.<slt_hash>.svg` — a badge does
-  not have to be pre-generated. What is **not** yet live is off-platform independent
-  verification (signing, `did:web`); that's the v1.1 work described at the end, and
-  every claim below is labelled **live**, **in dev**, or **coming** so you always know
-  where you stand.
+  not have to be pre-generated. Off-platform verification is live too: credentials
+  are signed with a managed production key against the resolvable issuer identity
+  `did:web:credentials.andamio.io`, and on 2026-07-23 the first signed badge passed
+  1EdTech's Open Badges 3.0 validator **13 of 13 checks, zero warnings**. Every claim
+  below is labelled **live**, **in dev**, or **coming** so you always know where you
+  stand.
 </Callout>
 
 ## The four layers
@@ -55,20 +57,26 @@ record it points at, whether a hosted database or an on-chain token whose image 
 only attached metadata. Here the geometry itself is the proof, decodable straight
 back to the chain.
 
-### 3. The Open Badges 3.0 form — the portable standard *(live: format · in dev: signature)*
+### 3. The Open Badges 3.0 form — the portable standard *(live)*
 
 Underneath the image, a badge is expressed as an **Open Badges 3.0 / W3C
 Verifiable Credential 2.0** JSON-LD object — the interoperability standard the
 credentialing world already reads. The OB 3.0 `achievement.image` field points at
-the badge SVG; Andamio's own extension terms (`onChainAnchor`, `onChainAttestation`,
-`accessToken`, `requires`, `prereqAttestation`) carry the Cardano-native facts that
-plain OB 3.0 has no vocabulary for. The extension context is published at
-`/context/v0.jsonld` and the hosted issuer identity at `/issuer`.
+the badge SVG; Andamio's own extension terms (`courseOwner`, and the
+`OnChainCredentialAnchor` evidence fields `network`, `policyId`, `asset`, and
+`claimTxHash`) carry the Cardano-native facts that plain OB 3.0 has no vocabulary
+for. The extension context is published at `/context/v1.jsonld` and the hosted
+issuer identity at `/issuer`. Published context versions are immutable: adding
+vocabulary mints the next version URL, and every earlier version keeps serving
+forever, so a credential signed long ago still canonicalizes exactly as it did on
+signing day.
 
-The **format** is delivered and has passed the 1EdTech Open Badges validator. The
-**cryptographic signature** that lets an outside verifier trust the object without
-calling Andamio is the v1.1 work below — today the object is correct OB 3.0 but not
-yet independently signed.
+The **format** and the **cryptographic signature** are both delivered. A signed
+badge carries a W3C Data Integrity proof (`eddsa-rdfc-2022`), produced by a managed
+production key and checkable against `did:web:credentials.andamio.io` by any
+Data-Integrity-capable OB 3.0 / VC verifier, with no call to Andamio. On 2026-07-23,
+1EdTech's member validator independently confirmed the first signed badge: 13 of 13
+checks passed, zero warnings.
 
 ### 4. The on-chain anchor — where identity actually lives *(live)*
 
@@ -103,30 +111,31 @@ For the integrator's URL contract and embed snippet, see
 **The image is presentation-layer; the on-chain anchor is identity.** Get that
 right and the rest follows: art can be restyled without breaking credentials,
 badges embed anywhere as plain images, and "verification" means checking the rings
-(and soon the signature) back against the chain — not trusting a hosted database.
+and the signature back against the chain and Andamio's published issuer key — not
+trusting a hosted database.
 
-## Where it's going — v1.1 portability *(in dev / coming)*
+## The portability rollout — what's live, what's left
 
-Today a badge's proof is its **Proof-Ring encoding plus the on-chain anchor** —
-Cardano-native, and strongest for a Cardano-aware audience. v1.1 makes a badge
-**independently verifiable off-platform**, so anyone can trust it without trusting
-Andamio and without touching Cardano tooling:
+The v1.1 portability work makes a badge **independently verifiable off-platform**,
+so anyone can trust it without trusting Andamio and without touching Cardano
+tooling. Most of it is now live:
 
 - **Ed25519 signing** with a managed key, and a **signed OB 3.0 Verifiable
-  Credential baked into the badge** — self-verifying, no call to our server.
+  Credential baked into the badge** — self-verifying, no call to our server. *(live)*
 - **`did:web:credentials.andamio.io`** as a resolvable issuer identity, so a
-  standard verifier can fetch the signing key and check the signature.
-- A **status list** for suspension/revocation signalling.
+  standard verifier can fetch the signing key and check the signature. *(live)*
+- A **status list** for suspension/revocation signalling. *(live)*
 - A **third-party embed component** and a **standalone wallet-connect viewer**, so a
   holder's badges can be shown and verified anywhere, no Andamio account required.
+  *(coming)*
 
-<Callout type="warn" title="Honest scope of 'independently verifiable'">
-  v1.1 is in active development, built one verifiable slice at a time. When it
-  lands, the accurate claim is that badges are verifiable by **Data-Integrity-capable
-  OB 3.0 / VC verifiers** (e.g. spruce, 1EdTech), not by *every* tool that calls
-  itself an OB 3.0 verifier — many read only JWS-style credentials and will not read
-  Andamio's Data Integrity JSON-LD credential. Until v1.1 ships, the honest proof
-  story remains Proof-Ring + on-chain anchor.
+<Callout type="warn" title="Scope of 'independently verifiable'">
+  Signed badges are verifiable by **Data-Integrity-capable OB 3.0 / VC verifiers**
+  (e.g. SpruceID's `ssi`, 1EdTech's validator), not by *every* tool that calls itself
+  an OB 3.0 verifier — many read only JWS-style credentials and will not read
+  Andamio's Data Integrity JSON-LD credential. That is Open Badges reality, not an
+  Andamio gap. For any badge not yet carrying a baked signature, the proof story
+  remains Proof-Ring plus on-chain anchor.
 </Callout>
 
 ## Go deeper

--- a/content/docs/credential-badges/how-it-works.mdx
+++ b/content/docs/credential-badges/how-it-works.mdx
@@ -1,0 +1,140 @@
+---
+title: How Credential Badges Work
+description: A five-minute, end-to-end read on what an Andamio Credential Badge is — the image, the Proof-Ring encoding, the Open Badges 3.0 form, and the on-chain anchor that makes it a credential and not a picture — plus how one resolves and where the portability work is going.
+---
+
+A **credential badge** is the visible face of an on-chain Andamio credential: a
+self-contained image that shows a learner's achievement as something a person can
+look at, hold, and post anywhere. It is free and open source, and that is the
+point. Anyone can look at a real badge, understand what an Andamio credential is,
+and start building with it.
+
+The important thing to internalize first: **the art *is* the proof.** A badge is
+not a decorative stand-in for a record kept somewhere else — its geometry encodes
+the credential's on-chain identity and round-trips back to the chain. This page
+takes one apart, layer by layer, then shows how it resolves and where it's going.
+
+<Callout type="info" title="Live on Cardano mainnet (v1.0)">
+  Credential badges are live in production. Any credential resolves on demand at
+  `https://credentials.andamio.io/badges/<policy_id>.<slt_hash>.svg` — a badge does
+  not have to be pre-generated. What is **not** yet live is off-platform independent
+  verification (signing, `did:web`); that's the v1.1 work described at the end, and
+  every claim below is labelled **live**, **in dev**, or **coming** so you always know
+  where you stand.
+</Callout>
+
+## The four layers
+
+A badge is four things stacked on top of each other. Only the top one is a picture.
+
+### 1. The image — presentation *(live)*
+
+Each badge is a self-contained SVG. Fonts are embedded, so it renders standalone
+in any browser or `<img>` tag with **no call back to Andamio and no client
+library**. The imagery is deliberately presentation-layer: an issuer can refresh a
+badge's art without invalidating a single issued credential, because the image is
+a *pointer* to the credential, never the credential's identity. (See layer 4.)
+
+The SVGs are **build output, not hand-authored files** — each one is rendered
+deterministically from on-chain data by an open-source generator. Change the
+generator or the source data and regenerate; never hand-edit a badge.
+
+### 2. The Proof-Ring encoding — the "art is proof" layer *(live)*
+
+The two rings around the badge are not decoration. They encode the credential's
+on-chain identity directly into the geometry:
+
+- the **outer ring** encodes the course's on-chain minting-policy id, and
+- the **inner ring** encodes the Student Learning Target (SLT) credential hash.
+
+Because the encoding is deterministic, a badge **round-trips back to the chain**: a
+decoder reads the rings off the image and confirms they match the credential's
+real on-chain hashes. The image checks itself — no server, no trust in Andamio
+required for this step. Most "verified" badges pair a picture with a *separate*
+record it points at, whether a hosted database or an on-chain token whose image is
+only attached metadata. Here the geometry itself is the proof, decodable straight
+back to the chain.
+
+### 3. The Open Badges 3.0 form — the portable standard *(live: format · in dev: signature)*
+
+Underneath the image, a badge is expressed as an **Open Badges 3.0 / W3C
+Verifiable Credential 2.0** JSON-LD object — the interoperability standard the
+credentialing world already reads. The OB 3.0 `achievement.image` field points at
+the badge SVG; Andamio's own extension terms (`onChainAnchor`, `onChainAttestation`,
+`accessToken`, `requires`, `prereqAttestation`) carry the Cardano-native facts that
+plain OB 3.0 has no vocabulary for. The extension context is published at
+`/context/v0.jsonld` and the hosted issuer identity at `/issuer`.
+
+The **format** is delivered and has passed the 1EdTech Open Badges validator. The
+**cryptographic signature** that lets an outside verifier trust the object without
+calling Andamio is the v1.1 work below — today the object is correct OB 3.0 but not
+yet independently signed.
+
+### 4. The on-chain anchor — where identity actually lives *(live)*
+
+The credential's real identity is not in the image or the JSON — it is anchored in
+the learner's **Access Token global state on Cardano mainnet**. An Andamio
+credential is an attestation written into that on-chain state by a multi-party
+process (the course owner, an assessor, the chain itself, and Andamio's signer).
+Everything above — the image, the rings, the OB 3.0 object — is a portable *view*
+of that anchor, so that a non-Cardano audience can read a fact that lives on
+Cardano. Burn or transfer the on-chain credential and the anchor changes; the
+picture was only ever a pointer to it.
+
+## How a badge resolves
+
+Serving is **static-first with an on-demand render fallback**, so every valid
+credential resolves whether or not its badge was pre-built *(live)*:
+
+1. **Hit** — if the badge is in the pre-generated set, nginx serves it from disk.
+2. **Miss** — the request falls through to a render service, which reads the course
+   and module **titles** from the Andamio gateway (titles are the only thing
+   fetched), renders the SVG, and caches it. First request renders; repeats serve
+   from cache.
+
+You never need to know which path served you — the response is the same
+`image/svg+xml`. The badge *geometry* is reproducible entirely offline, because the
+proof is the on-chain-anchored ring encoding, not anything the render service adds.
+For the integrator's URL contract and embed snippet, see
+[Resolve & Display a Badge](/docs/credential-badges/resolve-and-display).
+
+## The one idea to keep
+
+**The image is presentation-layer; the on-chain anchor is identity.** Get that
+right and the rest follows: art can be restyled without breaking credentials,
+badges embed anywhere as plain images, and "verification" means checking the rings
+(and soon the signature) back against the chain — not trusting a hosted database.
+
+## Where it's going — v1.1 portability *(in dev / coming)*
+
+Today a badge's proof is its **Proof-Ring encoding plus the on-chain anchor** —
+Cardano-native, and strongest for a Cardano-aware audience. v1.1 makes a badge
+**independently verifiable off-platform**, so anyone can trust it without trusting
+Andamio and without touching Cardano tooling:
+
+- **Ed25519 signing** with a managed key, and a **signed OB 3.0 Verifiable
+  Credential baked into the badge** — self-verifying, no call to our server.
+- **`did:web:credentials.andamio.io`** as a resolvable issuer identity, so a
+  standard verifier can fetch the signing key and check the signature.
+- A **status list** for suspension/revocation signalling.
+- A **third-party embed component** and a **standalone wallet-connect viewer**, so a
+  holder's badges can be shown and verified anywhere, no Andamio account required.
+
+<Callout type="warn" title="Honest scope of 'independently verifiable'">
+  v1.1 is in active development, built one verifiable slice at a time. When it
+  lands, the accurate claim is that badges are verifiable by **Data-Integrity-capable
+  OB 3.0 / VC verifiers** (e.g. spruce, 1EdTech), not by *every* tool that calls
+  itself an OB 3.0 verifier — many read only JWS-style credentials and will not read
+  Andamio's Data Integrity JSON-LD credential. Until v1.1 ships, the honest proof
+  story remains Proof-Ring + on-chain anchor.
+</Callout>
+
+## Go deeper
+
+- [Anatomy of a Credential Badge](/docs/credential-badges) — the same four layers as
+  an interactive explorer.
+- [Resolve & Display a Badge](/docs/credential-badges/resolve-and-display) — the
+  integrator's URL contract and embed.
+- [`credential-badges` on GitHub](https://github.com/Andamio-Platform/credential-badges)
+  — the open-source generator, the served static host, and the roadmap. Run
+  `make verify` to decode a real badge and watch it round-trip to its on-chain hashes.

--- a/content/docs/credential-badges/meta.json
+++ b/content/docs/credential-badges/meta.json
@@ -3,6 +3,7 @@
     "icon": "Award",
     "pages": [
         "index",
+        "how-it-works",
         "resolve-and-display"
     ]
 }


### PR DESCRIPTION
## What

An ongoing documentation pass for **Credential Badges** in andamio-docs. This PR is a **living branch** — it stays open and accumulates commits as the Credential Badges docs progress, rather than landing one page at a time.

## In this PR so far

- **`content/docs/credential-badges/how-it-works.mdx`** — the "how it works" page for Credential Badges, brought fully current with production (v1.1 signing live, `did:web` live, baking live; hosted verification page still coming).
- **`content/docs/credential-badges/meta.json`** — registers the page in the sidebar nav.
- **`components/credential-badges/anatomy-layers.ts`** — the interactive anatomy explorer, kept in lockstep with the prose page's claims.
- **`.gitignore`** — ignore `.worktrees/`.

## Latest: context v1 + independent verification (2026-07-23)

Two things landed after PR #63's v1.1 flip; the latest commit reconciles the docs with both:

- **Context v0 → v1.** The 2026-07-21 in-place mutation of `/context/v0.jsonld` broke 1EdTech verification (verifier document caches are effectively unbounded, so they canonicalized against a stale copy and rejected a valid signature). The fix published the full vocabulary at a fresh, immutable `/context/v1.jsonld` and re-signed against it; v0 is frozen and serves forever. Both pages now name v1 and state the version-immutability rule.
- **1EdTech 13/13.** 1EdTech's member validator independently confirmed the first signed badge — 13 of 13 checks, zero warnings. Added as concrete proof on the prose page (callout + layer 3) and in the anatomy explorer.

The extension-term list now reflects what the signed credential actually carries (`courseOwner` + `OnChainCredentialAnchor` evidence fields). Wording gate held throughout: verifiable by **DI-capable OB 3.0 / VC verifiers** (spruce, 1EdTech), never "any OB3 verifier".

## Status

Branch is now current with `main` (merged in #61's orphan-route guard and #63's v1.1 flip). `tsc --noEmit` clean. More Credential Badges documentation may land here as it's written.
