### PR TITLE
docs(credential-badges): update to v1.1 reality

### DIFF
--- a/components/credential-badges/anatomy-layers.ts
+++ b/components/credential-badges/anatomy-layers.ts
@@ -83,11 +83,13 @@ export const LAYERS: Layer[] = [
     tagline: "What travels with the file",
     what:
       "Because the badge is a self-contained SVG, the identifying data travels with the image. " +
-      "Today that is the Proof-Ring encoding of the (policy_id, slt_hash) pair — readable back " +
-      "out of the file itself, wherever it ends up.",
+      "Today the file carries two things: the Proof-Ring encoding of the (policy_id, slt_hash) " +
+      "pair, and — baked inside it — the credential's signed Open Badge, both readable straight " +
+      "out of the file wherever it ends up.",
     why:
-      "The file can be stored anywhere and the identifiers it carries can be recomputed by " +
-      "anyone — no Andamio lookup required to know which course and target it refers to.",
+      "The file can be stored anywhere: the identifiers it carries can be recomputed by anyone " +
+      "with no Andamio lookup, and the embedded signed credential lets the image verify itself " +
+      "offline against a DI-capable OB 3.0 verifier.",
     claims: [
       {
         text:
@@ -97,11 +99,12 @@ export const LAYERS: Layer[] = [
       },
       {
         text:
-          "Open Badges “baking” — embedding the signed verifiable credential inside the " +
-          "SVG/PNG (e.g. <openbadges:credential verify=\"<JWS>\">) so the image self-verifies " +
-          "offline. The spec is finalized; today's badges carry the Proof-Ring encoding, not an " +
-          "embedded signed credential.",
-        label: "coming",
+          "Open Badges “baking” is live — every badge embeds its signed Verifiable Credential in " +
+          "a CDATA <openbadges:credential> block (OB 3.0 §5.3.2.1) so the image self-verifies " +
+          "offline. The proof is a W3C Data Integrity proof (eddsa-rdfc-2022), not VC-JWT, so it " +
+          "carries no verify= attribute. Today's badges carry both the Proof-Ring encoding and " +
+          "this embedded signed credential.",
+        label: "live",
       },
     ],
     hotspot: { x: 77, y: 25 },
@@ -113,15 +116,18 @@ export const LAYERS: Layer[] = [
     tagline: "The portable, standards-based view",
     what:
       "Andamio expresses each credential in the Open Badges 3.0 / W3C Verifiable Credentials 2.0 " +
-      "JSON-LD form — a standards-based shape any compliant verifier can read. The Andamio-specific " +
-      "terms (onChainAnchor, onChainAttestation, accessToken, requires, prereqAttestation) are " +
-      "defined in a hosted, versioned JSON-LD context, and a hosted issuer Profile identifies " +
-      "Andamio as the issuer.",
+      "JSON-LD form — a standards-based shape that DI-capable OB 3.0 verifiers can read. The " +
+      "Andamio-specific terms (AttestationHost, OnChainCredentialAnchor, onChainAnchor, " +
+      "onChainAttestation, courseOwner, claimTxHash, policyId, accessToken, requires, " +
+      "prereqAttestation) are defined in a hosted, versioned JSON-LD context, and a hosted issuer " +
+      "Profile — typed [\"Profile\",\"AttestationHost\"] — identifies Andamio as the attestation host.",
     why:
-      "The OB3 / W3C VC form is a portable view of the on-chain anchor, so a verifier that has " +
-      "never heard of Cardano can still read and trust the credential — that's what makes an " +
-      "Andamio credential integrate with any app that speaks Open Badges. The DID layer gives the " +
-      "credential a cryptographic issuer identity so a verifier can check who signed it.",
+      "The OB3 / W3C VC form is a portable view of the on-chain anchor, so a DI-capable verifier " +
+      "that has never heard of Cardano can still read and trust the credential — that's what lets " +
+      "an Andamio credential integrate with apps that speak Open Badges Data Integrity (e.g. " +
+      "spruce, 1EdTech). JWS-only verifiers can't read Data Integrity proofs — that's OB 3.0 " +
+      "reality, not an Andamio gap. The DID layer gives the credential a cryptographic issuer " +
+      "identity so a verifier can check who signed it.",
     claims: [
       {
         text: "/context/v0.jsonld serves Andamio's OB 3.0 extension terms (versioned, immutable).",
@@ -133,15 +139,22 @@ export const LAYERS: Layer[] = [
       },
       {
         text:
-          "did:web:credentials.andamio.io is the production issuer identity — its " +
-          "/.well-known/did.json is not yet published; today credentials use a throwaway did:key " +
-          "and reference the hosted Profile URL informationally.",
-        label: "coming",
+          "did:web:credentials.andamio.io is the production issuer identity, and its " +
+          "/.well-known/did.json is published (type Multikey, key #key-2026-07). Credentials are " +
+          "signed under the did:web key — no throwaway did:key.",
+        label: "live",
       },
       {
         text:
-          "The signing service that emits and lets you verify a credential — KMS-backed signing " +
-          "plus a human-facing verification page.",
+          "KMS-backed signing is live: credentials sign per holder on demand, and the service is " +
+          "anchor-gated — it refuses to sign anything the chain doesn't attest (zero KMS " +
+          "operations on a failed anchor read).",
+        label: "live",
+      },
+      {
+        text:
+          "A hosted, human-facing verification page. Today verification is done by DI-capable " +
+          "OB 3.0 verifiers (e.g. spruce, 1EdTech) and by the self-verifying baked badge.",
         label: "coming",
       },
     ],

--- a/content/docs/credential-badges/index.mdx
+++ b/content/docs/credential-badges/index.mdx
@@ -26,8 +26,10 @@ written for the **technical integrator, not the buyer** — credibility, not a s
   - **In dev** — the data or mechanism exists, but a surface around it is still being built.
   - **Coming** — designed and specified, not yet implemented.
 
-  Today's live system runs on **Cardano mainnet**. Credential badges (v1.0) render and serve on
-  demand for any credential. Nothing undelivered is described as if it shipped.
+  Today's live system runs on **Cardano mainnet**. Credential badges (v1.1) render and serve on
+  demand for any credential, and each badge now embeds a signed, independently-verifiable
+  credential — the `did:web` issuer identity and anchor-gated KMS signing are live. Nothing
+  undelivered is described as if it shipped.
 </Callout>
 
 </div>

--- a/content/docs/credential-badges/resolve-and-display.mdx
+++ b/content/docs/credential-badges/resolve-and-display.mdx
@@ -8,7 +8,7 @@ Displaying one is as simple as pointing an `<img>` at it. This page is the
 integrator's contract: the URL shape, how resolution works, and the few edge
 cases worth handling.
 
-<Callout type="info" title="Live on mainnet (v1.0)">
+<Callout type="info" title="Live on mainnet (v1.1)">
   Badge serving is live on Cardano **mainnet**. Any credential resolves on demand,
   so a badge does not have to be pre-generated.
 </Callout>
@@ -77,5 +77,8 @@ lookup degrades to a placeholder instead of a broken image:
   badge art without invalidating any issued credential, so the image is cached
   but not immutable. See [Anatomy of a Credential Badge](/docs/credential-badges)
   for what's actually inside.
-- **Independent verification (signing, `did:web`, baking) is v1.1.** Today a
-  badge's proof is its Proof-Ring encoding plus the on-chain anchor.
+- **Independent verification is live in v1.1.** Each badge bakes a signed
+  credential (`eddsa-rdfc-2022`, `did:web`), verifiable by DI-capable OB 3.0
+  verifiers (e.g. spruce, 1EdTech) with no call to Andamio. The Proof-Ring
+  encoding and on-chain anchor remain, now alongside the embedded signed
+  credential — see [Anatomy of a Credential Badge](/docs/credential-badges).


### PR DESCRIPTION
## What

Credential Badges **v1.1** shipped independent verification, so the docs no longer match production. This flips the stale claims to current state. Every flipped `live` claim maps to a surface that returned 200 (or the documented proof shape) when re-verified **2026-07-22**.

## Changes

**`components/credential-badges/anatomy-layers.ts`**
- **Layer 2 (baking)** `coming → live` — every badge embeds its signed VC in a CDATA `<openbadges:credential>` block (OB 3.0 §5.3.2.1). Corrected the mechanism: it's a W3C Data Integrity proof (`eddsa-rdfc-2022`), **not** VC-JWT, so **removed the wrong `verify="<JWS>"` example** — embedded-proof credentials omit `verify=`.
- **Layer 3 (`did:web`)** `coming → live` — `/.well-known/did.json` is published (`Multikey`, `#key-2026-07`); removed throwaway-`did:key` language.
- **Layer 3 (signing)** split — KMS signing `live` (anchor-gated: refuses to sign what the chain doesn't attest); hosted verification page **stays `coming`** (`/verify` still 404).
- **Layer 3 correctness** — "any compliant verifier" / "any app that speaks Open Badges" → **DI-capable** OB 3.0 verifiers (spruce, 1EdTech); JWS-only verifiers can't read DI proofs (OB 3.0 reality, not an Andamio gap).
- **Layer 3 `what`** — issuer Profile typed `["Profile","AttestationHost"]`; expanded the JSON-LD context term list.

**`content/docs/credential-badges/index.mdx`** — Anatomy callout `v1.0 → v1.1`.
**`content/docs/credential-badges/resolve-and-display.mdx`** — callout `v1.0 → v1.1`; rewrote the backwards "independent verification is v1.1 [future]" bullet to describe it as live.

## Not changed (deliberately)
- **Layer 4 `in-dev` claims** (`evidence_hash` retrieval, andamioscan surfacing) — left as-is; not independently confirmed shipped.
- The honest **live / coming / in-dev** labeling is intact on every page — no label dropped or blurred.

## Verification (2026-07-22)
```
200  /context/v0.jsonld
200  /.well-known/did.json
200  /status/key-epoch-2026-07.json
404  /verify            # keeps the verification-page claim "coming"
badge SVG embeds: DataIntegrityProof · eddsa-rdfc-2022 · did:web:credentials.andamio.io#key-2026-07
                  (no verify= attribute)
```
- `tsc --noEmit` — 0 errors
- `npm run docs-headings` — 54 MDX files clean
- Straggler sweep for pre-v1.1 phrasing under `content/docs/credential-badges/` — no hits (the two `v1.0` hits repo-wide are the andamio-bot, genuinely v1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)