### PR TITLE
docs: remove private-vault paths from repo content

### DIFF
--- a/.claude/skills/analyze-transaction/SKILL.md
+++ b/.claude/skills/analyze-transaction/SKILL.md
@@ -60,7 +60,7 @@ This skill parses decoded Cardano transaction CBORs from the Atlas API and creat
 After completing the YAML documentation, verify and update the monorepo transaction definition:
 
 1. **Locate the definition file:**
-   - Path: `~/projects/01-projects/andamio-platform/andamio-platform-monorepo/packages/andamio-transactions/src/definitions/v2/{system}/{role}/{tx-name}.ts`
+   - Path: `$REPOS/andamio-platform-monorepo/packages/andamio-transactions/src/definitions/v2/{system}/{role}/{tx-name}.ts`
    - If the file doesn't exist, create it following existing patterns
 
 2. **Verify alignment between YAML and TypeScript:**
@@ -201,7 +201,7 @@ See `.claude/skills/analyze-transaction/example-tx.md` for a complete worked exa
 
 **Outputs (all required):**
 1. YAML file at `public/yaml/transactions/v2/{system}/{role}/{tx-name}.yaml`
-2. TypeScript definition at `~/projects/01-projects/andamio-platform/andamio-platform-monorepo/packages/andamio-transactions/src/definitions/v2/{system}/{role}/{tx-name}.ts`
+2. TypeScript definition at `$REPOS/andamio-platform-monorepo/packages/andamio-transactions/src/definitions/v2/{system}/{role}/{tx-name}.ts`
 3. Registry updates (if new validators/policies discovered)
 </example>
 
@@ -216,7 +216,7 @@ See `.claude/skills/analyze-transaction/example-tx.md` for a complete worked exa
 6. **Ask questions when uncertain** - Better to clarify than guess incorrectly
 7. **File path alignment**:
    - YAML: `public/yaml/transactions/v2/{system}/{role}/{tx-name}.yaml`
-   - TS: `~/projects/01-projects/andamio-platform/andamio-platform-monorepo/packages/andamio-transactions/src/definitions/v2/{system}/{role}/{tx-name}.ts`
+   - TS: `$REPOS/andamio-platform-monorepo/packages/andamio-transactions/src/definitions/v2/{system}/{role}/{tx-name}.ts`
    - MDX: `content/docs/protocol/v2/transactions/{system}/{role}/{tx-name}.mdx`
 
 ## Existing Transactions (as templates)

--- a/.claude/skills/audit-docs/detect-drift.sh
+++ b/.claude/skills/audit-docs/detect-drift.sh
@@ -2,8 +2,8 @@
 # detect-drift.sh — surface stale version pins in andamio-docs public developer surface.
 #
 # Sources of truth:
-#   - GATEWAY_TAG   ← devkit VERSIONS  (~/projects/01-projects/andamio-dev-kit-internal/VERSIONS)
-#   - CLI tag       ← latest git tag in andamio-cli (~/projects/01-projects/andamio-cli)
+#   - GATEWAY_TAG   ← devkit VERSIONS  ($REPOS/andamio-dev-kit-internal/VERSIONS)
+#   - CLI tag       ← latest git tag in andamio-cli ($REPOS/andamio-cli)
 #
 # Scope (deliberately narrow):
 #   Includes — content/docs/api/guides/**, state-machine/**, getting-started.mdx

--- a/.claude/skills/guide-pipeline/SKILL.md
+++ b/.claude/skills/guide-pipeline/SKILL.md
@@ -207,7 +207,7 @@ Create a GitHub issue in the app repo for a problem found during guide writing.
 
 ## Cross-Repo Sync
 
-The `guide-tracker.json` in this directory is the shared source of truth. The `ux-readiness` skill in the app repo (`~/projects/01-projects/andamio-platform/andamio-app-v2`) reads and writes to this file via absolute filesystem path.
+The `guide-tracker.json` in this directory is the shared source of truth. The `ux-readiness` skill in the app repo (`$REPOS/andamio-app-v2`) reads and writes to this file via absolute filesystem path.
 
 - Changes from the app repo appear as unstaged modifications here — commit them during your next docs session
 - Issue states are always verified live via `gh issue view`

--- a/docs/plans/2026-03-17-feat-publish-txpipe-audit-report-plan.md
+++ b/docs/plans/2026-03-17-feat-publish-txpipe-audit-report-plan.md
@@ -21,7 +21,7 @@ Resolves [#12](https://github.com/andamio-platform/andamio-docs/issues/12). The 
 
 ### 1. Copy PDF to public assets
 
-Source: `~/projects/01-projects/andamio-pioneers-cohort-001/andamio-v2-audit.pdf`
+Source: `$REPOS/andamio-pioneers-cohort-001/andamio-v2-audit.pdf`
 Destination: `public/documents/andamio-v2-audit.pdf`
 
 This establishes `public/documents/` as the pattern for serving PDF documents (no precedent exists in this repo).

--- a/docs/plans/2026-06-29-002-feat-protocol-docs-redesign-plan.md
+++ b/docs/plans/2026-06-29-002-feat-protocol-docs-redesign-plan.md
@@ -3,13 +3,13 @@ title: "feat: Protocol docs redesign — intro · source-backed validators · tr
 status: completed
 type: feat
 date: 2026-06-29
-origin: ../../../02-areas/andamio/docs/plans/2026-06-29-protocol-docs-redesign-handoff.md
+origin: design-decided handoff, authored in a private planning vault (not team-accessible)
 plan_depth: deep
 ---
 
 # feat: Protocol docs redesign — intro · source-backed validators · transaction-sequence steppers
 
-> **Origin:** `orch/docs/plans/2026-06-29-protocol-docs-redesign-handoff.md` (a self-contained, design-decided handoff). Design is settled; this is execution. **Target repo:** `andamio-docs`. All paths below are repo-relative to `andamio-docs/`.
+> **Origin:** a self-contained, design-decided handoff authored outside this repo. Design is settled; this is execution. **Target repo:** `andamio-docs`. All paths below are repo-relative to `andamio-docs/`.
 > **Validator source of truth:** `andamio-aiken-contracts` `plutus.json` @ `351b267` (on-chain code is immutable/deployed — current).
 
 ---
@@ -407,7 +407,7 @@ andamio-docs/
 
 ## Sources & Research
 
-- **Origin handoff:** `orch/docs/plans/2026-06-29-protocol-docs-redesign-handoff.md` (design-decided; this plan is its execution).
+- **Origin handoff:** a design-decided handoff authored outside this repo (design-decided; this plan is its execution).
 - **Blueprint (verified):** `andamio-aiken-contracts/plutus.json` @ `351b267` — extraction confirmed 12 validators and action lists matching the handoff table exactly (`validators[].title` → name; `redeemer.schema.$ref` → `definitions[].anyOf[].title` → actions).
 - **Reuse target:** `components/credential-badges/BadgeAnatomyExplorer.tsx` + `components/credential-badges/anatomy-layers.ts` (rail/stage/panel + ARIA + data/render split); registered via `mdx-components.tsx`; full-width pairing in `app/docs/[[...slug]]/page.tsx`.
 - **Generation precedents:** `scripts/generate-v2-tx-docs.mjs` (source-data → MDX), `scripts/check-contract-manifest.ts` (prebuild drift guard). *(`scripts/docs-coverage-check.ts` is **not** a usable precedent — it targets a non-existent `protocol/v1` tree and a missing `validator-registry-v1.yaml`, and is not in the `prebuild` chain; it already errors and is unrelated to this work.)*

--- a/docs/plans/2026-06-29-003-feat-remove-papers-to-landing-plan.md
+++ b/docs/plans/2026-06-29-003-feat-remove-papers-to-landing-plan.md
@@ -3,7 +3,7 @@ title: "feat: Remove paper stubs from docs, redirect to the landing"
 type: feat
 status: completed
 created: 2026-06-29
-origin: ../../../02-areas/andamio/docs/plans/2026-06-29-docs-remove-papers-to-landing-handoff.md
+origin: design-decided handoff, authored in a private planning vault (not team-accessible)
 target_repo: andamio-docs
 ---
 
@@ -287,7 +287,7 @@ landing URL; glossary page still resolves at `/docs/glossary`.
 
 ## Sources & Research
 
-- Origin handoff: `../../../02-areas/andamio/docs/plans/2026-06-29-docs-remove-papers-to-landing-handoff.md`
+- Origin handoff: a design-decided handoff authored outside this repo
 - Stub pages confirmed empty (`> **Coming soon.**`): `content/docs/light-paper.mdx`,
   `content/docs/api/building-on-andamio.mdx`.
 - Existing redirects + the building-on-andamio chain: `next.config.mjs:18-112` (chain at line 37).

--- a/docs/plans/2026-06-29-004-feat-trust-verification-zone-plan.md
+++ b/docs/plans/2026-06-29-004-feat-trust-verification-zone-plan.md
@@ -2,7 +2,7 @@
 type: plan
 status: completed
 created: 2026-06-29
-origin: ../../../02-areas/andamio/docs/plans/2026-06-29-docs-trust-verification-zone-handoff.md
+origin: design-decided handoff, authored in a private planning vault (not team-accessible)
 target_repo: andamio-docs
 branch: feat/trust-verification-zone
 ---
@@ -130,7 +130,7 @@ Both are exact-match sources; confirmed no existing rule matches these paths, so
 
 ## Sources & Research
 
-- Origin handoff: `../../../02-areas/andamio/docs/plans/2026-06-29-docs-trust-verification-zone-handoff.md`
+- Origin handoff: a design-decided handoff authored outside this repo
 - Verified directly on branch `feat/trust-verification-zone` (off `main` @ `cc2c547`): root `meta.json` layout, `protocol/v2/meta.json`, file existence, the 6 stale links (grep), and the absence of any `protocol/v2/:path*` wildcard in `next.config.mjs`.
 - IA context: memory `project_docs_ia_six_root_roadmap_aligned` (six product roots + horizontal Reference/Trust zones).
 - MDX gotchas (from project CLAUDE.md): content-collections silently drops files with invalid frontmatter — verify generated output after moves; never `replace_all` across frontmatter delimiters.

--- a/docs/plans/2026-06-30-001-feat-tune-orama-docs-search-plan.md
+++ b/docs/plans/2026-06-30-001-feat-tune-orama-docs-search-plan.md
@@ -4,7 +4,7 @@ status: completed
 date: 2026-06-30
 type: feat
 depth: standard
-origin: ../../../02-areas/andamio/docs/plans/2026-06-30-andamio-docs-handoff-orama-search-tuning.md
+origin: design-decided handoff, authored in a private planning vault (not team-accessible)
 target_repo: andamio-docs
 ---
 
@@ -219,7 +219,7 @@ The `tag` emitted by `buildIndex` (U1) is what the dialog's tag bar (U2) filters
 
 ## Sources & Research
 
-- **Origin handoff:** `02-areas/andamio/docs/plans/2026-06-30-andamio-docs-handoff-orama-search-tuning.md` (James's decision + the what/why/gotchas this plan executes).
+- **Origin handoff:** a design-decided handoff authored outside this repo (James's decision + the what/why/gotchas this plan executes).
 - **Installed types (verified, load-bearing — corrected the origin's nesting guess):**
   - `node_modules/fumadocs-core/dist/search/server.d.ts` — `createFromSource` `Options<Page>`, `AdvancedOptions.search`, `AdvancedIndex` fields (`tag`, `structuredData`, `keywords`).
   - `node_modules/@orama/orama/dist/browser/types.d.ts` — `SearchParams.tolerance` / `.threshold` (default `0`).

--- a/docs/solutions/workflow-issues/docs-release-sync-drift-2026-05-20.md
+++ b/docs/solutions/workflow-issues/docs-release-sync-drift-2026-05-20.md
@@ -71,7 +71,7 @@ The docs PR is a tick-through of the checklist. Trade-off: requires release auth
 A script that compares authoritative version sources against version strings in `content/docs/**/*.mdx`. Authoritative sources:
 
 - `devkit/VERSIONS` — `GATEWAY_TAG` (only this for public-docs purposes; ignore `DB_API_TAG`, `ATLAS_TAG`, `INDEXER_TAG`, `SIDECAR_TAG` — those are internal services excluded from public docs).
-- `git -C ~/projects/01-projects/andamio-cli describe --tags --abbrev=0` — current CLI tag.
+- `git -C $REPOS/andamio-cli describe --tags --abbrev=0` — current CLI tag.
 
 Sketch (run from `andamio-docs`):
 
@@ -173,4 +173,4 @@ content/docs/protocol/v2/state-machine/index.mdx:261: v2.1.1-rc12               
 - `.claude/skills/transaction-audit/SKILL.md` — domain-specific instance of release-cycle drift (Atlas swagger → V2 transaction YAML); should cross-link as the V2-transactions-only instance of this practice.
 - `.claude/skills/v2-docs-audit/SKILL.md` — coverage tracking for V2 transaction MDX; same family, narrower scope.
 - `.claude/skills/guide-pipeline/SKILL.md` "Cross-Repo Sync" section — proves the cross-repo tracker pattern; scope is onboarding guides + UX readiness.
-- `~/projects/01-projects/andamio-dev-kit-internal/docs/releases/v2.3/RELEASE_REPORT.md` — the source-of-truth artifact a release-cycle hook would consume.
+- `$REPOS/andamio-dev-kit-internal/docs/releases/v2.3/RELEASE_REPORT.md` — the source-of-truth artifact a release-cycle hook would consume.


### PR DESCRIPTION
Citations pointing into a private Obsidian vault, which no reader of this repo can open. This repo is **public**, so they were also disclosing the vault's internal structure.

Provenance is preserved; the paths are removed. Each citation now describes what the source was instead of pointing at an unreachable path.

Found by a path guard that scans repo files and issue/PR bodies for personal-vault and absolute-home paths. Note it also reports `~/projects/...` developer-setup paths in this repo, which are a milder class and are **not** changed here.