### PR TITLE
Point developers at andamio-dev instead of openapi-specs

### DIFF
--- a/content/docs/developer-community/repositories.mdx
+++ b/content/docs/developer-community/repositories.mdx
@@ -35,7 +35,7 @@ Application templates and development tools.
 | Repository | Description |
 |------------|-------------|
 | [andamio-app-template](https://github.com/Andamio-Platform/andamio-app-template) | Next.js application template |
-| [openapi-specs](https://github.com/Andamio-Platform/openapi-specs) | OpenAPI specifications |
+| [andamio-dev](https://github.com/Andamio-Platform/andamio-dev) | Developer reference: public API contract, transaction loop reference, integration course |
 | [brand-hub](https://github.com/Andamio-Platform/brand-hub) | Brand assets and guidelines |
 
 ## Documentation
@@ -52,6 +52,7 @@ The following repositories are deprecated and should not be used for new develop
 |------------|--------|-------------|
 | andamio-db-api | Deprecated | [andamio-db-api-go](https://github.com/Andamio-Platform/andamio-db-api-go) |
 | andamio-platform-monorepo | Deprecated | Individual repositories above |
+| openapi-specs | Deprecated | [andamio-dev](https://github.com/Andamio-Platform/andamio-dev) — see `specs/andamio-api.yaml` |
 
 <Callout type="warn">
 If you find links to deprecated repositories in our documentation, please report them via [GitHub Issues](https://github.com/Andamio-Platform/andamio-docs/issues).


### PR DESCRIPTION
`openapi-specs` is being deprecated and archived ([openapi-specs#1](https://github.com/Andamio-Platform/openapi-specs/pull/1)). Its `openapi.yaml` was last updated **2026-01-18** and was the unfiltered export rather than the public contract — it published four administrative routes in a public repo.

This page was the one place in our documentation still pointing developers at it, so deprecating the repo without this change would just relocate the stale pointer.

## Changes

- Moved `openapi-specs` to the **Deprecated Repositories** table, with `andamio-dev` named as its replacement.
- Added **`andamio-dev`** to Templates & Tools. It holds the public API contract (`specs/andamio-api.yaml`), the transaction loop reference, and the integration course — and it was not listed on this page at all.

## Noted, not changed

This page links to several repositories that are private or internal — `ls-course`, `ls-project`, `ls-instance`, `andamio-api`, `andamioscan`, `andamio-atlas-api-v2`, `andamio-db-api-go`, `brand-hub`. On a public documentation site those are 404s for anyone outside the org.

That may well be deliberate — the page arguably documents the architecture rather than only what a reader can open. Flagging it rather than acting on it, since it is a separate editorial call from this deprecation.