### PR TITLE
docs(api): v2.x API envelope contract + JWKS verification

### DIFF
--- a/content/docs/api/accounts/api-integration.mdx
+++ b/content/docs/api/accounts/api-integration.mdx
@@ -27,12 +27,6 @@ const headers = {
 Once authenticated, include both headers in all requests:
 
 ```typescript
-const headers = {
-  "Content-Type": "application/json",
-  "X-API-Key": APP_API_KEY,
-  "Authorization": `Bearer ${userJwt}`,
-};
-
 // Example: List user's courses
 const res = await fetch(`${API}/course/owner/courses/list`, {
   method: "GET",
@@ -89,26 +83,80 @@ See [Environment Reference](/docs/api/reference/environments) for full configura
 
 ## Error Responses
 
-API errors return JSON with `error` and `message` fields:
+The Andamio API uses two error shapes depending on the endpoint. Both are in active use.
+
+### Legacy shape
+
+Used by auth, transaction, billing, and most existing endpoints:
 
 ```json
 {
-  "error": "UNAUTHORIZED",
-  "message": "Invalid or expired JWT"
+  "status_code": 401,
+  "message": "Unauthorized: Invalid or missing credentials.",
+  "details": "optional debug info"
 }
 ```
 
-Common error codes:
+| Field | Required | Description |
+|-------|----------|-------------|
+| `status_code` | Yes | HTTP status code repeated in the body |
+| `message` | Yes | Human-readable error message |
+| `details` | No | Optional debug information |
 
-| Code | Meaning |
-|------|---------|
-| `UNAUTHORIZED` | Missing or invalid auth headers |
-| `FORBIDDEN` | User lacks permission for this action |
-| `NOT_FOUND` | Resource doesn't exist |
-| `VALIDATION_ERROR` | Invalid request body |
-| `TX_BUILD_FAILED` | Transaction building failed |
+### Error envelope shape
+
+Used by merged data endpoints (`/v2/course/*/merged`, `/v2/project/*/merged`, module, lesson, SLT endpoints):
+
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Assignment not found",
+    "details": "optional debug info"
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `error.code` | Yes | Semantic error code string |
+| `error.message` | Yes | Human-readable error message |
+| `error.details` | No | Optional debug information |
+
+### HTTP status to error code mapping
+
+| HTTP | Semantic code |
+|------|--------------|
+| 400 | `BAD_REQUEST` |
+| 401 | `UNAUTHORIZED` |
+| 403 | `FORBIDDEN` |
+| 404 | `NOT_FOUND` |
+| 409 | `CONFLICT` |
+| 422 | `UNPROCESSABLE_ENTITY` |
+| 429 | `TOO_MANY_REQUESTS` |
+| 500 | `INTERNAL_SERVER_ERROR` |
+| 502 | `BAD_GATEWAY` |
+| 503 | `SERVICE_UNAVAILABLE` |
 
 See [Error Handling](/docs/api/core/error-handling) for recovery patterns.
+
+## Rate Limit Headers
+
+Every API response includes rate limit information in the response headers:
+
+| Header | Description |
+|--------|-------------|
+| `X-RateLimit-Limit` | Maximum requests allowed in the current window |
+| `X-RateLimit-Remaining` | Requests remaining in the current window |
+| `X-RateLimit-Reset` | Unix timestamp when the window resets |
+
+When you exceed your limit, the API returns `429 Too Many Requests`. Use `X-RateLimit-Reset` to schedule your retry. Rate limits are determined by your billing tier — see [Billing](/docs/api/billing) for the limits per plan.
+
+## Issuer Route Auth
+
+Some endpoints under `/api/v2/auth/issuer/*` operate with stricter auth requirements than standard v2 routes. These routes reject requests that supply **both** `X-API-Key` and `Authorization` — sending both returns `400 Bad Request`. Supply only the credential the endpoint requires.
+
+For all other `/api/v2/*` routes, both headers are accepted together (the standard pattern above).
 
 ## Next Steps
 

--- a/content/docs/api/accounts/authentication.mdx
+++ b/content/docs/api/accounts/authentication.mdx
@@ -278,6 +278,100 @@ async function login(walletName: string): Promise<AuthResult> {
 | `JWT_EXPIRED` | Token expired | Re-authenticate |
 | `FORBIDDEN` | User lacks role for action | Check user's roles |
 
+## Access Token Verification (Third-Party)
+
+If you are building a service that needs to confirm a user holds an Andamio Access Token — without relying on the Andamio gateway to gate access — use the two-step verification flow. It produces a signed **attestation JWT** you can verify offline.
+
+### When to use this
+
+Use this flow when your backend needs cryptographic proof that a user's wallet holds an Access Token with a specific alias. The attestation JWT lets you verify that proof offline using the public key, without a second round-trip to the gateway.
+
+### 1. Start a verification session
+
+```bash
+curl -X POST https://preprod.api.andamio.io/api/v2/verify/session \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"alias": "alice"}'
+```
+
+Response:
+
+```json
+{
+  "session_id": "550e8400-e29b-41d4-a716-446655440000",
+  "nonce": "Sign this message to verify Andamio Access Token ownership: a1b2c3d4...",
+  "expires_at": "2026-03-10T12:05:00Z"
+}
+```
+
+The session expires in **5 minutes**. Have the user sign the `nonce` with their CIP-30 wallet immediately.
+
+### 2. Complete verification
+
+```typescript
+// User signs the nonce
+const { signature, key } = await wallet.signData(address, nonce);
+
+// Submit to complete verification
+const res = await fetch(`${API}/verify/complete`, {
+  method: "POST",
+  headers: { "X-API-Key": APP_API_KEY, "Content-Type": "application/json" },
+  body: JSON.stringify({
+    session_id: sessionId,
+    signature: { signature, key },
+  }),
+});
+
+const { verified, alias, wallet_address, attestation_jwt } = await res.json();
+```
+
+The gateway checks two things before issuing the attestation:
+1. The CIP-30 signature is valid for the nonce
+2. The signing wallet actually holds the on-chain Access Token for the alias (checked against the blockchain — a valid signature alone is not enough)
+
+Both must pass. If either fails, `verified` is `false` and no `attestation_jwt` is returned.
+
+### 3. Verify the attestation offline
+
+The attestation JWT is signed with RS256. Fetch the public key once and cache it:
+
+```typescript
+const API_BASE = "https://preprod.api.andamio.io"; // note: no /api/v2
+const jwks = await fetch(`${API_BASE}/.well-known/jwks.json`).then(r => r.json());
+// jwks.keys[0] contains: { kty: "RSA", use: "sig", alg: "RS256", kid: "andamio-api-attestation-key", n, e }
+```
+
+Verify the JWT with any standard RS256 library:
+
+```typescript
+import { jwtVerify, importJWK } from "jose";
+
+const key = await importJWK(jwks.keys[0], "RS256");
+const { payload } = await jwtVerify(attestationJwt, key, {
+  issuer: "andamio-api",
+  audience: "access-token-verification",
+});
+
+// payload.sub  = alias ("alice")
+// payload.wallet_address = bech32 wallet address
+// payload.exp  = expiry (10 minutes from issuance)
+```
+
+The attestation JWT expires in **10 minutes** — it is a short-lived proof, not a session token.
+
+### Verification failure codes
+
+| Error code | Meaning |
+|------------|---------|
+| `alias_not_found` | No Access Token exists for this alias |
+| `session_not_found` | Session ID not found or belongs to a different API key |
+| `session_expired` | Session was not completed within 5 minutes |
+| `session_already_used` | Session has already been consumed |
+| `invalid_signature` | CIP-30 signature did not verify against the nonce |
+| `wallet_not_holder` | Signature is valid but the wallet does not hold the Access Token on-chain |
+| `service_unavailable` | A backend service (chain indexer) is temporarily unavailable |
+
 ## Next Steps
 
 - [Developer Accounts](/docs/api/accounts/developer-accounts) — Developer registration, email verification, and Developer JWT

--- a/content/docs/api/core/api-concepts.mdx
+++ b/content/docs/api/core/api-concepts.mdx
@@ -1,9 +1,77 @@
 ---
 title: API Concepts
-description: Source field architecture, safe refetch timing, and merged endpoints
+description: Response envelope, pagination, source field architecture, and safe refetch timing
 ---
 
 Core concepts for working with the Andamio API beyond basic request/response patterns.
+
+## Response Envelope
+
+Every successful Andamio API response wraps its payload in a standard envelope:
+
+```json
+{
+  "data": { ... },
+  "meta": {
+    "warning": "optional warning message",
+    "pagination": { ... }
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `data` | Yes | The response payload — shape varies by endpoint |
+| `meta` | No | Optional metadata object |
+| `meta.warning` | No | Non-fatal warning the caller should be aware of |
+| `meta.pagination` | No | Present on paginated list endpoints |
+
+### Pagination
+
+List endpoints use one of two pagination formats depending on whether the list is a snapshot or an append-only feed.
+
+**Snapshot lists** (courses, projects, commitments — data that can change between pages):
+
+```json
+{
+  "data": [ ... ],
+  "meta": {
+    "pagination": {
+      "page": 1,
+      "page_size": 20,
+      "total": 100
+    }
+  }
+}
+```
+
+**Cursor-based feeds** (append-only data like audit logs):
+
+```json
+{
+  "data": [ ... ],
+  "meta": {
+    "pagination": {
+      "next_cursor": 12345,
+      "has_more": true
+    }
+  }
+}
+```
+
+Cursor tokens are opaque — do not parse or construct them client-side. Pass the value of `next_cursor` directly as the `cursor` query parameter on the next request.
+
+### Warnings
+
+`meta.warning` is a non-fatal signal that the response succeeded but data may be partial. It appears on merged endpoints when one of the two backend systems is unavailable:
+
+| Warning | Meaning |
+|---------|---------|
+| `"DB API unavailable, showing on-chain data only"` | Database is down — response contains on-chain data only, no off-chain metadata |
+| `"Andamioscan unavailable, on-chain state not available"` | Blockchain indexer is down — response contains DB data only, no on-chain state |
+| `"DB API partially unavailable, some content may be missing"` | Database partially degraded — some records may be missing from the response |
+
+When `meta.warning` is present, treat the response as degraded — display what you have but avoid taking actions that depend on the completeness of the data.
 
 ## The Source Field
 
@@ -21,7 +89,7 @@ The Andamio protocol is a shared commons — anyone can create courses and proje
 
 ```typescript
 const courses = await fetch(`${API}/course/user/courses/list`, { headers });
-const data = await courses.json();
+const { data } = await courses.json();
 
 for (const course of data) {
   switch (course.source) {

--- a/content/docs/api/core/error-handling.mdx
+++ b/content/docs/api/core/error-handling.mdx
@@ -214,5 +214,5 @@ curl https://andamioscan.io/api/tx/$TX_HASH
 
 - [API Concepts](/docs/api/core/api-concepts) — Safe refetch timing and the source field
 - [API Integration](/docs/api/accounts/api-integration) — Complete transaction flow
-- [Transaction State Machine](/docs/protocol/v2#the-transaction-lifecycle) — State transition details
+- [Transaction State Machine](/docs/apps-tooling/andamio-app/transaction-state-machine) — State transition details
 - [API Reference](https://api.andamio.io) — Endpoint documentation


### PR DESCRIPTION
## Summary

- **Response envelope** — documents the `{data, meta}` wrapper, both pagination formats (snapshot + cursor), and `meta.warning` degraded-state signals
- **Error shapes** — documents both coexisting error shapes (legacy `{status_code, message}` and envelope `{error: {code, message}}`), full HTTP→semantic code mapping, rate limit headers, and issuer route auth distinction
- **JWKS / Access Token verification** — documents the two-step `POST /verify/session` → `POST /verify/complete` flow with offline attestation JWT verification via `GET /.well-known/jwks.json`
- **Broken anchor fix** — `error-handling.mdx` next steps link updated to point to the correct transaction state machine page

## Files changed

- `content/docs/api/core/api-concepts.mdx` — response envelope, pagination, warnings
- `content/docs/api/accounts/api-integration.mdx` — both error shapes, rate limit headers, issuer route auth
- `content/docs/api/accounts/authentication.mdx` — JWKS + access token verification flow
- `content/docs/api/core/error-handling.mdx` — broken anchor fix

## Test plan

- [ ] `npm run dev` — verify all four pages render without errors
- [ ] Check `api-concepts.mdx` — response envelope section appears above The Source Field
- [ ] Check `api-integration.mdx` — both error shapes present, rate limit headers section present
- [ ] Check `authentication.mdx` — Access Token Verification section renders at bottom of page
- [ ] Verify JWKS code example compiles (no undefined variables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)